### PR TITLE
Statistiikka

### DIFF
--- a/backend/knexfile.js
+++ b/backend/knexfile.js
@@ -4,12 +4,7 @@ require('dotenv').config()
 module.exports = {
     development: {
         client: 'pg',
-        connection: {
-            user: process.env.DB_USER,
-            host: process.env.DB_HOST,
-            database: process.env.DB_NAME,
-            password: process.env.DB_PASSWORD,
-        },
+        connection: `postgres://${process.env.DB_USER}:${process.env.DB_PASSWORD}@${process.env.DB_HOST}:${process.env.DB_PORT}/${process.env.DB_NAME}`,
         pool: {
             min: 2,
             max: 10,

--- a/backend/knexfile.js
+++ b/backend/knexfile.js
@@ -4,7 +4,12 @@ require('dotenv').config()
 module.exports = {
     development: {
         client: 'pg',
-        connection: `postgres://${process.env.DB_USER}:${process.env.DB_PASSWORD}@${process.env.DB_HOST}:${process.env.DB_PORT}/${process.env.DB_NAME}`,
+        connection: {
+            user: process.env.DB_USER,
+            host: process.env.DB_HOST,
+            database: process.env.DB_NAME,
+            password: process.env.DB_PASSWORD,
+        },
         pool: {
             min: 2,
             max: 10,

--- a/backend/src/database/migrations/20210217131859_create_parking_area_table.js
+++ b/backend/src/database/migrations/20210217131859_create_parking_area_table.js
@@ -6,6 +6,7 @@ exports.up = (knex) => {
         table.integer("capacity_estimate")
         table.timestamp("created_at").defaultTo(knex.fn.now())
         table.timestamp("updated_at").defaultTo(knex.fn.now())
+        table.string("road")
     })
 }
 

--- a/backend/src/database/migrations/20210217131859_create_parking_area_table.js
+++ b/backend/src/database/migrations/20210217131859_create_parking_area_table.js
@@ -1,15 +1,14 @@
-exports.up = (knex) => {
-    return knex.schema.createTable("parking_area", (table) => {
+exports.up = knex => {
+    return knex.schema.createTable('parking_area', table => {
         table.increments()
-        table.string("uid").notNullable()
-        table.jsonb("geometry").notNullable()
-        table.integer("capacity_estimate")
-        table.timestamp("created_at").defaultTo(knex.fn.now())
-        table.timestamp("updated_at").defaultTo(knex.fn.now())
-        table.string("road")
+        table.string('uid').notNullable()
+        table.jsonb('geometry').notNullable()
+        table.integer('capacity_estimate')
+        table.timestamp('created_at').defaultTo(knex.fn.now())
+        table.timestamp('updated_at').defaultTo(knex.fn.now())
     })
 }
 
-exports.down = (knex) => {
-    return knex.schema.dropTable("parking_area")
+exports.down = knex => {
+    return knex.schema.dropTable('parking_area')
 }

--- a/backend/src/database/migrations/20210305121218_modify_parking_area_table.js
+++ b/backend/src/database/migrations/20210305121218_modify_parking_area_table.js
@@ -1,0 +1,13 @@
+exports.up = function (knex) {
+    return knex.schema.alterTable('parking_area', table => {
+        table.string('road')
+        table.string('house_number')
+    })
+}
+
+exports.down = function (knex) {
+    return knex.schema.alterTable('parking_area', table => {
+        table.dropColumn('road')
+        table.dropColumn('house_number')
+    })
+}

--- a/backend/src/database/queries/parking_area.js
+++ b/backend/src/database/queries/parking_area.js
@@ -1,4 +1,4 @@
-const knex = require("../config")
+const knex = require('../config')
 
 // Database queries related to parking data
 
@@ -6,10 +6,50 @@ const getParkingAreas = async () => {
     return await knex.from('parking_area').select()
 }
 
-
-const getParkingHistoryByUid = async (uid, limit) => {
-    return await knex.from('parking_area_statistics').select().where({ uid }).orderBy('id', 'desc').limit(limit)
+const getParkingAreasByArray = async uids => {
+    return await knex.from('parking_area').select().whereIn('uid', uids)
 }
 
+const getParkingHistoryByUid = async (uid, limit) => {
+    return await knex
+        .from('parking_area_statistics')
+        .select()
+        .where({ uid })
+        .orderBy('id', 'desc')
+        .limit(limit)
+}
 
-module.exports = { getParkingAreas, getParkingHistoryByUid }
+const getPopularParkingAreas = async (hours, limit) => {
+    const toDate = new Date()
+    const fromDate = new Date(
+        new Date().setDate(Math.floor(toDate.getDate() - hours / 24)),
+    )
+
+    const { rows } = await knex.raw(
+        `
+        SELECT *
+        FROM (
+            SELECT uid, SUM(current_parking_count) AS parking_sum
+            FROM parking_area_statistics
+            WHERE created_at
+            BETWEEN ?
+            AND ?
+            GROUP BY uid
+        ) t
+        WHERE parking_sum > 0
+        ORDER BY parking_sum DESC
+        LIMIT ?
+        ;
+        `,
+        [fromDate, toDate, limit],
+    )
+
+    return rows
+}
+
+module.exports = {
+    getParkingAreas,
+    getParkingHistoryByUid,
+    getPopularParkingAreas,
+    getParkingAreasByArray,
+}

--- a/backend/src/database/queries/parking_area.js
+++ b/backend/src/database/queries/parking_area.js
@@ -1,14 +1,9 @@
-const { off } = require('../config')
 const knex = require('../config')
 
 // Database queries related to parking data
 
 const getParkingAreas = async () => {
     return await knex.from('parking_area').select()
-}
-
-const getParkingAreasByArray = async uids => {
-    return await knex.from('parking_area').select().whereIn('uid', uids)
 }
 
 const getParkingHistoryByUid = async (uid, limit) => {
@@ -57,5 +52,4 @@ module.exports = {
     getParkingAreas,
     getParkingHistoryByUid,
     getPopularParkingAreas,
-    getParkingAreasByArray,
 }

--- a/backend/src/database/queries/parking_area.js
+++ b/backend/src/database/queries/parking_area.js
@@ -16,7 +16,6 @@ const getParkingHistoryByUid = async (uid, limit) => {
 }
 
 const getPopularParkingAreas = async (fromDate, toDate, limit, offset) => {
-    // TODO: add street names
     return await knex
         .select('*')
         .from(

--- a/backend/src/database/queries/parking_area.js
+++ b/backend/src/database/queries/parking_area.js
@@ -38,7 +38,7 @@ const getPopularParkingAreas = async (fromDate, toDate, limit, offset) => {
                 .whereBetween('p_statistics.created_at', [fromDate, toDate])
                 .groupBy('p_statistics.uid')
                 .join('parking_area AS p', 'p_statistics.uid', '=', 'p.uid')
-                .select('geometry')
+                .select(['geometry', 'capacity_estimate'])
                 .groupBy('p.id')
                 .as('t'),
         )

--- a/backend/src/database/seeds/02-parking_area_roads.js
+++ b/backend/src/database/seeds/02-parking_area_roads.js
@@ -1,0 +1,32 @@
+const axios = require("axios")
+
+async function getRoad(lat, long) {
+  let address
+  await axios
+    .get('https://nominatim.openstreetmap.org/reverse?lat=' + lat + '&lon=' + long + '&format=json')
+    .then(response => {
+      address = response.data
+    })
+  return address.address.road
+}
+
+exports.seed = function (knex) {
+  return knex("parking_area")
+    .then(async function () {
+      try {
+        const data = await knex.from('parking_area').select()
+        for (const feature of data) {
+          const long = feature.geometry.coordinates[0][0][0][0]
+          const lat = feature.geometry.coordinates[0][0][0][1]
+          let address = await getRoad(lat, long)
+          console.log(address)
+          await knex("parking_area").where({ id: feature.id }).update({
+            road: address,
+          })
+        }
+      } catch (e) {
+        console.error(e)
+      }
+      return
+    })
+}

--- a/backend/src/database/utils/roads.json
+++ b/backend/src/database/utils/roads.json
@@ -1,0 +1,8349 @@
+[
+  {
+    "uid": "63c74937-9a4e-4ca4-bdb2-eb2dafb57b20",
+    "road": "Runeberginkatu",
+    "house_number": "4c"
+  },
+  {
+    "uid": "676fa28a-a36c-448c-b3ba-4c914cabf3b4",
+    "road": "Rautatientori"
+  },
+  {
+    "uid": "e6e92260-367e-48dd-b80f-c483590f65fe",
+    "road": "Eteläinen Hesperiankatu"
+  },
+  {
+    "uid": "7a9ef0ff-85ad-443e-8a95-b69ab507eaf2",
+    "road": "Salmisaarenranta"
+  },
+  {
+    "uid": "02060fc5-c330-4d2f-9abc-24e107998a52",
+    "road": "Salmisaarenranta"
+  },
+  {
+    "uid": "1efcec25-b969-4642-88c3-d3e99904b2ab",
+    "road": "Tammasaarenlaituri",
+    "house_number": "5 M"
+  },
+  {
+    "uid": "643e0362-6b8f-4c79-b41b-df2be805adab",
+    "road": "Kellosaarenkatu",
+    "house_number": "4"
+  },
+  {
+    "uid": "b1242d39-ab26-4b61-a144-dd70b4e93340",
+    "road": "Bernhardinkatu",
+    "house_number": "4"
+  },
+  {
+    "uid": "d39fb4af-ed12-4b2d-9603-ab8d3c241220",
+    "road": "Merimiehenkatu"
+  },
+  {
+    "uid": "f01941b9-228b-4880-86d7-8f689605cbc6",
+    "road": "Melkonkatu",
+    "house_number": "6"
+  },
+  {
+    "uid": "10314d45-87c8-4f15-949b-38f5de13c263",
+    "road": "Itälahdenkatu",
+    "house_number": "13"
+  },
+  {
+    "uid": "8f3482f7-1b92-41f3-b366-dfd4c817dcb4",
+    "road": "Melkonkuja"
+  },
+  {
+    "uid": "55f816ba-b762-4139-8447-54c4bd87daa4",
+    "road": "Purjeentekijänkuja",
+    "house_number": "11"
+  },
+  {
+    "uid": "633f8246-e03e-44ae-9875-800b74de44c4",
+    "road": "Särkiniementie",
+    "house_number": "6"
+  },
+  {
+    "uid": "0ce5b524-0c1c-4f9e-aa74-4a762bcd622d",
+    "road": "Länsilahdenkuja",
+    "house_number": "4"
+  },
+  {
+    "uid": "915a19cf-4516-4b21-a804-fcccaef3a608",
+    "road": "Nahkahousuntie",
+    "house_number": "3"
+  },
+  {
+    "uid": "a3bb6d7e-e63b-44f1-bb1e-d21678db7e32",
+    "road": "Itälahdenkatu",
+    "house_number": "15-17"
+  },
+  {
+    "uid": "ce36caa4-6fa1-4468-a4ab-82a5848fbd8b",
+    "road": "Itälahdenkatu",
+    "house_number": "27"
+  },
+  {
+    "uid": "b158a380-497a-4132-89b9-c1a254a6b4a6",
+    "road": "Melkonkatu",
+    "house_number": "21a"
+  },
+  {
+    "uid": "25d75a2d-c99c-453c-9a25-2e83cf19fc24",
+    "road": "Vattuniemen puistotie",
+    "house_number": "3"
+  },
+  {
+    "uid": "80aef04b-6f9b-41bc-84f8-89f7771a5d5c",
+    "road": "Vattuniemenkuja",
+    "house_number": "8"
+  },
+  {
+    "uid": "7277dba5-0ea2-48b9-91a8-19d8a14a45af",
+    "road": "Vattuniemenkatu",
+    "house_number": "23"
+  },
+  {
+    "uid": "051a3a2c-e036-44e9-bdac-7737d55ef0c3",
+    "road": "Vattuniemenranta",
+    "house_number": "2"
+  },
+  {
+    "uid": "5fecdf9e-596e-4e07-9fdf-31cedfb1451c",
+    "road": "Perttulantie"
+  },
+  {
+    "uid": "524562d6-0134-4497-a0cc-46bcc075c7b9",
+    "road": "Särkiniementie"
+  },
+  {
+    "uid": "b1d92309-c4c3-47d5-9bfd-314be5550a5e",
+    "road": "Särkiniementie"
+  },
+  {
+    "uid": "941f1b57-c92c-4191-87d2-df3aca4a24c1",
+    "road": "Haahkakuja",
+    "house_number": "1"
+  },
+  {
+    "uid": "9d23bcfc-6b29-4344-bb21-b593f37713bb",
+    "road": "Haahkatie",
+    "house_number": "10"
+  },
+  {
+    "uid": "4e6b3ef1-2f0e-44c2-9fd6-7b3c67db88a3",
+    "road": "Tallbergin puistotie",
+    "house_number": "10"
+  },
+  {
+    "uid": "35922d2a-0199-4c11-b761-04ded3a161d3",
+    "road": "Otavantie",
+    "house_number": "4"
+  },
+  {
+    "uid": "197c3f62-bdfc-4ba4-ac0f-6f3cd742bcf9",
+    "road": "Otavantie",
+    "house_number": "18"
+  },
+  {
+    "uid": "cf354429-0dea-4e75-a902-deaf0b2e8eb6",
+    "road": "Veneentekijäntie"
+  },
+  {
+    "uid": "2fa1d54c-5b9f-4030-aaf9-9986194f6d2b",
+    "road": "Särkiniementie",
+    "house_number": "3"
+  },
+  {
+    "uid": "fa872596-d229-45fa-9fc4-4a56f6cf43ec",
+    "road": "Meripuistotie"
+  },
+  {
+    "uid": "8da5131a-2bce-47c3-b4a6-467f1b175501",
+    "road": "Pajalahdentie"
+  },
+  {
+    "uid": "ef44a2eb-57ad-4889-bc38-c713fc2d59e2",
+    "road": "Rauhankatu"
+  },
+  {
+    "uid": "5e9398b9-0b55-4e12-8376-3246d7f6bbba",
+    "road": "Rauhankatu"
+  },
+  {
+    "uid": "77c6d254-af75-445d-acc3-4ef754cfeeee",
+    "road": "Katajanokanlaituri",
+    "house_number": "7"
+  },
+  {
+    "uid": "40bba1f0-a25a-4ad5-899e-2a17479c8bd0",
+    "road": "Itämerenkatu",
+    "house_number": "22"
+  },
+  {
+    "uid": "63692cb2-70d5-4389-9199-12a54db9ba76",
+    "road": "Itämerenkatu",
+    "house_number": "14"
+  },
+  {
+    "uid": "fe30990d-d0f7-4ecb-bf13-a0fd5116cab9",
+    "road": "Pohjoisesplanadi",
+    "house_number": "2"
+  },
+  {
+    "uid": "2d34951d-14bd-4b17-a22c-9c00b0f9fa56",
+    "road": "Pohjoisesplanadi",
+    "house_number": "41"
+  },
+  {
+    "uid": "f04fbb6c-9e73-4311-9dde-e2d298102b67",
+    "road": "Itämerenkatu",
+    "house_number": "26"
+  },
+  {
+    "uid": "ecc55166-1108-480c-8cb9-78202dbb1e43",
+    "road": "Puistokatu",
+    "house_number": "1B"
+  },
+  {
+    "uid": "e9f6f244-e017-4caa-8565-17501f39df7b",
+    "road": "Runeberginkatu"
+  },
+  {
+    "uid": "303c17d0-45c1-4fa0-aedc-b140de850ea8",
+    "road": "Johanneksentie",
+    "house_number": "8"
+  },
+  {
+    "uid": "afe64eb0-95a0-4639-96ae-9dbfaa0243f5",
+    "road": "Itämerenkatu",
+    "house_number": "8"
+  },
+  {
+    "uid": "42060650-530b-4d6b-87c4-fe8f5f66006f",
+    "road": "Pohjoinen Rautatiekatu"
+  },
+  {
+    "uid": "df4aa854-a00b-45ed-b01a-f8f4736bc114",
+    "road": "Aleksanterinkatu"
+  },
+  {
+    "uid": "0b4beedd-29bd-4894-8fc5-1668adee14b0",
+    "road": "Eteläinen Hesperiankatu"
+  },
+  {
+    "uid": "762c5a08-6ae8-4329-83a7-712548d6149a",
+    "road": "Eteläinen Hesperiankatu"
+  },
+  {
+    "uid": "1dc89524-8216-4837-94ba-1f5b4e34df03",
+    "road": "Ullankatu",
+    "house_number": "3"
+  },
+  {
+    "uid": "8c96d72d-b532-4998-a373-5907bae71943",
+    "road": "Saukonpaadenranta",
+    "house_number": "10"
+  },
+  {
+    "uid": "b95c861d-2cb5-4d40-9aeb-9f95c6f255ec",
+    "road": "Eteläinen Hesperiankatu",
+    "house_number": "30"
+  },
+  {
+    "uid": "98f89d15-1c14-436a-a6c1-3b422f8df8be",
+    "road": "Yrjö-Koskisen katu"
+  },
+  {
+    "uid": "235da555-8b5a-40e4-b297-a16df0356a1e",
+    "road": "Eteläinen Rautatiekatu"
+  },
+  {
+    "uid": "a96f3371-c4de-4f2f-a1cd-b05880398ea9",
+    "road": "Salmisaarenranta",
+    "house_number": "7 i"
+  },
+  {
+    "uid": "105f97e2-18bc-40da-8a1d-d6804f987710",
+    "road": "Rauhankatu"
+  },
+  {
+    "uid": "9bcb355f-08ad-4e8b-a2ee-0727532299b1",
+    "road": "Kivelänkatu",
+    "house_number": "3"
+  },
+  {
+    "uid": "30cd0393-cc01-45ff-8a23-78356bffda64",
+    "road": "Kivelänkatu",
+    "house_number": "3"
+  },
+  {
+    "uid": "8af6e1b1-c853-4b70-b5a9-b35eeb8f555b",
+    "road": "Itälahdenkatu",
+    "house_number": "5"
+  },
+  {
+    "uid": "a53aa53f-b780-48d6-918d-5034f4dae058",
+    "road": "Tammasaarenlaituri",
+    "house_number": "3"
+  },
+  {
+    "uid": "f1546e3a-5598-41a2-a028-e782089879bc",
+    "road": "Hernesaarenkatu",
+    "house_number": "17"
+  },
+  {
+    "uid": "5e793dc1-5880-4985-99e7-73e6e97ef7cd",
+    "road": "Chydeniuksentie",
+    "house_number": "1"
+  },
+  {
+    "uid": "63cc556f-0923-41a7-85e5-b56e72c387e4",
+    "road": "Siltavuorenranta"
+  },
+  {
+    "uid": "1a72d1fc-b975-4ef2-9a40-8536e00268c9",
+    "road": "Vattuniemen puistotie",
+    "house_number": "3"
+  },
+  {
+    "uid": "b8b6242e-0281-44ad-9111-7478b8c68a6c",
+    "road": "Senaatintori"
+  },
+  {
+    "uid": "8f837e49-38ca-4c3e-90a2-3174efa41a53",
+    "road": "Särkiniementie",
+    "house_number": "2"
+  },
+  {
+    "uid": "37f349a7-2c78-4a4e-884f-f5a5d71e44f7",
+    "road": "Kaapeliaukio"
+  },
+  {
+    "uid": "3fd50d14-ee4e-430e-a21b-3eb1fd519a6f",
+    "road": "Saukonpaadenranta",
+    "house_number": "4"
+  },
+  {
+    "uid": "3b59a506-f94d-4855-a7be-095afeaab3f8",
+    "road": "Konalantie"
+  },
+  {
+    "uid": "d20e80c9-a2b7-49b7-b38d-b8b60adc66a5",
+    "road": "Porkkalankatu"
+  },
+  {
+    "uid": "cdef42e2-4d79-4821-a707-369d50bdd256",
+    "road": "Porkkalankatu"
+  },
+  {
+    "uid": "d03edfd2-6ac5-4955-81b6-7ca869d536dc",
+    "road": "Porkkalankatu"
+  },
+  {
+    "uid": "fa9f048f-1077-4363-a91e-4dd26b9cb49d",
+    "road": "Laivasillankatu"
+  },
+  {
+    "uid": "7e11b99a-641a-46e6-94e9-98dd18b3bf4b",
+    "road": "Satamakatu"
+  },
+  {
+    "uid": "cbc76a57-599b-469c-9f42-9f0ead53de7c",
+    "road": "Melkonkuja"
+  },
+  {
+    "uid": "1784f845-73e8-42e5-b1fe-dc0113572179",
+    "road": "Porkkalankatu"
+  },
+  {
+    "uid": "129b0cb3-13e4-4608-9667-f16de13fa7b5",
+    "road": "Porkkalankatu"
+  },
+  {
+    "uid": "2ae1e5bd-0ffd-4d3c-a863-eb19ed714f25",
+    "road": "Melkonkatu",
+    "house_number": "1"
+  },
+  {
+    "uid": "e49bcc85-7ca4-421c-be4f-a4373b953b70",
+    "road": "Itälahdenkatu",
+    "house_number": "4"
+  },
+  {
+    "uid": "cd0e8ebf-79cc-41b6-833d-799ebd443bca",
+    "road": "Itälahdenkatu",
+    "house_number": "1"
+  },
+  {
+    "uid": "660ee6b0-601c-42dd-b288-929c1bba36bc",
+    "road": "Itälahdenkatu",
+    "house_number": "2"
+  },
+  {
+    "uid": "70ae488a-a57c-46f6-9a8c-1252cd21f477",
+    "road": "Itälahdenkatu",
+    "house_number": "1"
+  },
+  {
+    "uid": "3e8cac1f-4d82-4bd5-acab-8777620505e1",
+    "road": "Itälahdenkatu",
+    "house_number": "1"
+  },
+  {
+    "uid": "d83f8e51-e32d-4872-b3dd-4b8af84691ee",
+    "road": "Melkonkuja"
+  },
+  {
+    "uid": "4ed47c9b-e9e0-45bf-ba25-99fb9ef407dd",
+    "road": "Melkonkuja"
+  },
+  {
+    "uid": "659025de-fcd0-40b3-8895-6e2e6adb7357",
+    "road": "Vattuniemenkatu",
+    "house_number": "6"
+  },
+  {
+    "uid": "7a36f65f-e123-4492-b163-f4867b47df66",
+    "road": "Vattuniemenkatu",
+    "house_number": "2"
+  },
+  {
+    "uid": "dd006d10-8acb-49e0-99cd-8bcf44a8f065",
+    "road": "Vattuniemenkatu",
+    "house_number": "2"
+  },
+  {
+    "uid": "df4e38f4-2b8e-402c-a862-70d2241ea06a",
+    "road": "Purjeentekijänkuja"
+  },
+  {
+    "uid": "68c1a017-b398-45e5-b0cf-4fe1f75e522e",
+    "road": "Särkikuja",
+    "house_number": "2"
+  },
+  {
+    "uid": "8384bf07-1754-4d09-93a0-c33649074feb",
+    "road": "Purjeentekijänkuja"
+  },
+  {
+    "uid": "5c0d6be1-a4e1-4ad9-8866-b90591bae252",
+    "road": "Veneentekijäntie",
+    "house_number": "5"
+  },
+  {
+    "uid": "54b737ed-c5c3-443d-bfce-3504de7e97b7",
+    "road": "Nahkahousunpolku"
+  },
+  {
+    "uid": "757079cc-a592-4c12-944b-0e72858cfcad",
+    "road": "Melkonkatu",
+    "house_number": "7"
+  },
+  {
+    "uid": "8d55e808-8a65-43c3-be36-615342710e1d",
+    "road": "Melkonkatu",
+    "house_number": "14"
+  },
+  {
+    "uid": "1602d095-0a83-4d2e-9730-7ad7fe941f0e",
+    "road": "Särkiniementie",
+    "house_number": "3"
+  },
+  {
+    "uid": "6203c2d7-f526-41d8-b238-0a79d91f15c9",
+    "road": "Särkiniementie",
+    "house_number": "5"
+  },
+  {
+    "uid": "89a6d5f1-1082-435c-9ac1-b6ec2c349022",
+    "road": "Särkiniementie",
+    "house_number": "10"
+  },
+  {
+    "uid": "32c58ae3-92c1-4852-a794-e5bbb3cf5b62",
+    "road": "Särkiniementie",
+    "house_number": "9"
+  },
+  {
+    "uid": "ee213216-cf9a-4f87-961b-7489f44a8897",
+    "road": "Nahkahousuntie"
+  },
+  {
+    "uid": "1b7d140d-c0f8-4cd7-890f-3648f372decf",
+    "road": "Nahkahousuntie"
+  },
+  {
+    "uid": "a0796c59-fca7-4cae-973b-70f15ae03ffb",
+    "road": "Nahkahousuntie"
+  },
+  {
+    "uid": "32b25c28-3408-4dc3-8d90-086c9f7ec334",
+    "road": "Nahkahousuntie"
+  },
+  {
+    "uid": "780d0087-7bd1-469e-95b4-5fb52d9523d0",
+    "road": "Nahkahousuntie",
+    "house_number": "7"
+  },
+  {
+    "uid": "12cbbb4d-cf47-430b-ac2e-d3035c02b71a",
+    "road": "Nahkahousuntie",
+    "house_number": "3"
+  },
+  {
+    "uid": "bcbc367e-b12b-47a0-9166-5671c4f8aaf1",
+    "road": "Särkiniementie",
+    "house_number": "11"
+  },
+  {
+    "uid": "010e6cdd-61b3-478a-8642-e2ea674ea40b",
+    "road": "Särkiniementie",
+    "house_number": "22"
+  },
+  {
+    "uid": "e499788c-8961-4971-95b0-f949f457bfd1",
+    "road": "Itälahdenkatu"
+  },
+  {
+    "uid": "145b2ad9-f772-428e-993b-2bcc129e5e43",
+    "road": "Itälahdenkatu"
+  },
+  {
+    "uid": "0a985b69-75bb-4798-8297-5eb44dd7d58b",
+    "road": "Itälahdenkatu",
+    "house_number": "27"
+  },
+  {
+    "uid": "b88895af-4854-4f95-af7b-31114230adc3",
+    "road": "Vattuniemenkuja",
+    "house_number": "3"
+  },
+  {
+    "uid": "ca38bf29-664f-437d-ac3f-d2b9e556e9e3",
+    "road": "Melkonkatu",
+    "house_number": "15"
+  },
+  {
+    "uid": "f5f5ab73-50d8-420f-ba95-186bb5dbc7e6",
+    "road": "Melkonkatu",
+    "house_number": "21a"
+  },
+  {
+    "uid": "a198b50b-0366-47f3-9ecb-d75caf5544aa",
+    "road": "Melkonkatu",
+    "house_number": "21a"
+  },
+  {
+    "uid": "b52ef3f5-9a65-46c9-bf86-6fe939f55c5c",
+    "road": "Melkonkatu",
+    "house_number": "28"
+  },
+  {
+    "uid": "96daee75-8851-4d2f-8856-158e7553bdbc",
+    "road": "Itälahdenkatu",
+    "house_number": "27"
+  },
+  {
+    "uid": "23c5caea-4bf6-42ba-92a3-df56a790e17a",
+    "road": "Melkonkatu",
+    "house_number": "26"
+  },
+  {
+    "uid": "32606c8b-e653-486c-a8b1-b5c1bbd3b9c5",
+    "road": "Kiviaidankatu",
+    "house_number": "3"
+  },
+  {
+    "uid": "74a5b871-7d38-4d42-8781-a8e3cd040e00",
+    "road": "Vattuniemenkatu",
+    "house_number": "23"
+  },
+  {
+    "uid": "f6abbf24-293e-4f4f-8809-cfd8be1920fb",
+    "road": "Vattuniemenkatu",
+    "house_number": "19"
+  },
+  {
+    "uid": "e6306abc-640c-4462-afac-414ffa1f3752",
+    "road": "Veneentekijäntie",
+    "house_number": "16"
+  },
+  {
+    "uid": "de052ed7-9b60-49d9-9780-6776db6ff744",
+    "road": "Veneentekijäntie",
+    "house_number": "20"
+  },
+  {
+    "uid": "7ed14978-5b4a-449b-8e80-e1311a0ddfea",
+    "road": "Veneentekijäntie",
+    "house_number": "20"
+  },
+  {
+    "uid": "bb647c73-363f-475c-aa4b-b7fa56eba646",
+    "road": "Veneentekijänkuja",
+    "house_number": "4"
+  },
+  {
+    "uid": "ce68cd32-a5d1-42aa-8887-b4b338926b24",
+    "road": "Veneentekijänkuja",
+    "house_number": "4"
+  },
+  {
+    "uid": "cfbe9dfa-e9bb-4881-96a5-b7b5d5e9a195",
+    "road": "Salakkakuja",
+    "house_number": "4"
+  },
+  {
+    "uid": "6f589398-7cad-445d-b5ea-9ded1c314adf",
+    "road": "Vattuniemenkuja"
+  },
+  {
+    "uid": "e74602f2-b238-499d-910f-953d4ff8d4ec",
+    "road": "Vattuniemenkatu",
+    "house_number": "23"
+  },
+  {
+    "uid": "e0a407f2-32d7-4e59-9c4c-c1ffcf807375",
+    "road": "Vattuniemenkatu",
+    "house_number": "23"
+  },
+  {
+    "uid": "e4d3264b-ab3a-455b-ba6a-b77278c1632b",
+    "road": "Vattuniemenkuja",
+    "house_number": "3"
+  },
+  {
+    "uid": "3a6ea1f3-59a0-4325-8cfb-14186a830642",
+    "road": "Vattuniemenkuja"
+  },
+  {
+    "uid": "b62a7dc9-7987-40f5-8ae2-bf923b6df365",
+    "road": "Vattuniemenranta",
+    "house_number": "2"
+  },
+  {
+    "uid": "94a50238-1162-4bbb-88d0-90b0b1456f9b",
+    "road": "Kiviaidankatu",
+    "house_number": "9"
+  },
+  {
+    "uid": "82a8fe03-0cdf-48bf-9256-976f0c66e492",
+    "road": "Vattuniemenkatu",
+    "house_number": "22"
+  },
+  {
+    "uid": "eec42381-b19f-48c6-9203-74630c1347a5",
+    "road": "Vattuniemenkatu"
+  },
+  {
+    "uid": "eb4af8cf-b39d-4571-8524-2452bfd6bb46",
+    "road": "Särkiniementie",
+    "house_number": "25"
+  },
+  {
+    "uid": "28599fe7-c865-4aa7-ac50-760b0a440d13",
+    "road": "Perttulantie"
+  },
+  {
+    "uid": "ccca803c-4f46-4e2a-93ba-1cf8f3a0a26e",
+    "road": "Särkiniementie"
+  },
+  {
+    "uid": "cedc350a-0a25-4b81-b0a9-cd6efeae4687",
+    "road": "Särkiniementie"
+  },
+  {
+    "uid": "be909f31-fd37-422e-8efb-311276744b95",
+    "road": "Haahkakuja",
+    "house_number": "5"
+  },
+  {
+    "uid": "f2ccf77d-a9a7-408e-9a60-5ef2a4615eb3",
+    "road": "Haahkakuja",
+    "house_number": "5"
+  },
+  {
+    "uid": "e163d907-76e8-4d9e-80ec-87bb8c54a1e3",
+    "road": "Haahkakuja",
+    "house_number": "5"
+  },
+  {
+    "uid": "dc6c1b21-597f-401c-93ed-7a29761c606f",
+    "road": "Haahkakuja",
+    "house_number": "1"
+  },
+  {
+    "uid": "5ce9cd2c-71cc-4d89-884c-9b99854864e7",
+    "road": "Särkiniementie"
+  },
+  {
+    "uid": "900fc804-4735-42c8-b6f2-b15305f9e3a2",
+    "road": "Haahkatie",
+    "house_number": "12"
+  },
+  {
+    "uid": "1c8c578f-3019-4b03-8944-54ab8302142c",
+    "road": "Haahkatie",
+    "house_number": "2"
+  },
+  {
+    "uid": "bd46216f-3a58-42c9-9e71-80dacb3472f8",
+    "road": "Tallbergin puistotie",
+    "house_number": "14"
+  },
+  {
+    "uid": "41df07c7-d6ca-41ba-b96f-8224f96a42f7",
+    "road": "Tallbergin puistotie",
+    "house_number": "12"
+  },
+  {
+    "uid": "9dac81a9-9461-4921-9215-08c2f9a01bf1",
+    "road": "Tallbergin puistotie",
+    "house_number": "10"
+  },
+  {
+    "uid": "79db7fbd-7d3d-4ba6-b120-9f8ca53ff474",
+    "road": "Otavantie",
+    "house_number": "1"
+  },
+  {
+    "uid": "3ba65b92-4fc3-440a-bfa2-28769cae4959",
+    "road": "Tallbergin puistotie"
+  },
+  {
+    "uid": "2bc71aa6-2281-4ab8-8e1d-a505cf4d4b9f",
+    "road": "Tallbergin puistotie"
+  },
+  {
+    "uid": "fdbfd25b-e4b0-4a99-95a2-a0bc93d61b2a",
+    "road": "Tallbergin puistotie"
+  },
+  {
+    "uid": "a9a99ae3-bd60-4f69-981c-26805da4f7e3",
+    "road": "Otavantie",
+    "house_number": "5"
+  },
+  {
+    "uid": "05ff5e0a-84f4-4b8b-bbb1-bf874f047b48",
+    "road": "Tallbergin puistotie",
+    "house_number": "7"
+  },
+  {
+    "uid": "25bb3191-67f7-4ff4-af55-37fcc6fc009d",
+    "road": "Heikkiläntie",
+    "house_number": "7"
+  },
+  {
+    "uid": "674d2946-a5d8-4d11-9c61-a10eeb34bb9f",
+    "road": "Heikkiläntie",
+    "house_number": "5"
+  },
+  {
+    "uid": "fd90936d-56ac-40c6-a198-391f46b71b98",
+    "road": "Heikkiläntie",
+    "house_number": "1"
+  },
+  {
+    "uid": "8c28cfdb-4ef8-4e84-909f-8301e6fabe91",
+    "road": "Heikkiläntie",
+    "house_number": "1"
+  },
+  {
+    "uid": "525fc0cb-c500-478d-9e8c-699e8116a7a4",
+    "road": "Vattuniemen puistotie",
+    "house_number": "11"
+  },
+  {
+    "uid": "1585ed73-ee4e-461a-bbfc-10a49a6e20b1",
+    "road": "Veneentekijäntie"
+  },
+  {
+    "uid": "247e83ea-9bce-4ef1-9b3f-42d479331d04",
+    "road": "Gyldénintie"
+  },
+  {
+    "uid": "6a22ebef-9e6a-446b-a32e-88b166de3908",
+    "road": "Gyldénintie",
+    "house_number": "2"
+  },
+  {
+    "uid": "1ba1ad37-df1f-437f-aa77-2350775d797b",
+    "road": "Kauppaneuvoksentie",
+    "house_number": "20"
+  },
+  {
+    "uid": "8b1214a3-1de1-48b3-a488-bcb1bba04a34",
+    "road": "Pajalahdentie"
+  },
+  {
+    "uid": "97bf4f46-5dc2-41c1-a9dc-5c55034ebb63",
+    "road": "Pajalahdentie",
+    "house_number": "10b"
+  },
+  {
+    "uid": "61eeccfe-c8c5-4573-9251-1dca76c9b8cd",
+    "road": "Pajalahdentie"
+  },
+  {
+    "uid": "5e559cd3-e615-4903-8489-1377322d6a0f",
+    "road": "Amiraalinkatu",
+    "house_number": "3"
+  },
+  {
+    "uid": "411e3073-19ad-4d8b-90ae-78afbfa6986a"
+  },
+  {
+    "uid": "23142939-9104-432a-971d-caf86de28559",
+    "road": "Otavantie",
+    "house_number": "7"
+  },
+  {
+    "uid": "837a4d87-1c9c-4e47-9c5c-12e761d3fef4",
+    "road": "Kauppaneuvoksentie",
+    "house_number": "20"
+  },
+  {
+    "uid": "10468f1d-9367-493e-bb90-11685c5e0cdb",
+    "road": "Koillisväylä",
+    "house_number": "2"
+  },
+  {
+    "uid": "68b0ed55-d25f-4d5c-b9c9-dc027fd72f2f",
+    "road": "Pajalahdentie"
+  },
+  {
+    "uid": "1bd32245-f3b2-4190-a9d7-400ad009984f",
+    "road": "Pajalahdentie"
+  },
+  {
+    "uid": "4be08e67-e7e9-4a7d-8202-b759b3e3656e",
+    "road": "Kauppaneuvoksentie"
+  },
+  {
+    "uid": "a272d305-880c-4e68-a9c3-36e31dc4ca7e",
+    "road": "Katajanokanranta"
+  },
+  {
+    "uid": "a8a0c495-851f-4906-b194-e5e330519137",
+    "road": "Kauppaneuvoksentie"
+  },
+  {
+    "uid": "3ab8d32f-ca8c-447d-aae7-162e69db89f1",
+    "road": "Pohjoiskaari",
+    "house_number": "5"
+  },
+  {
+    "uid": "e0b20bcb-23ce-4fe3-8539-2b35c7d730ca",
+    "road": "Pohjoiskaari"
+  },
+  {
+    "uid": "20829f56-ff29-4025-be50-42a54d5dd967",
+    "road": "Pohjoiskaari"
+  },
+  {
+    "uid": "457b10bb-a406-42c1-b024-0e7d6b36eb92",
+    "road": "Meripuistotie",
+    "house_number": "7"
+  },
+  {
+    "uid": "e866371d-e9f7-4a3d-aae1-103089c4b9d5",
+    "road": "Katajanokanranta"
+  },
+  {
+    "uid": "da2f5ab3-1f72-4b1a-941c-234c61aa8711",
+    "road": "Lauttasaarentie",
+    "house_number": "2a"
+  },
+  {
+    "uid": "2b9a49fb-3c8f-4dc0-9d65-d7990908bd57",
+    "road": "Katajanokanranta"
+  },
+  {
+    "uid": "5c2787df-d954-4d0e-9f88-592e4b32c212",
+    "road": "Pohjoiskaari",
+    "house_number": "18"
+  },
+  {
+    "uid": "9d8907eb-f972-40b3-8a0d-9c63a3a789bd",
+    "road": "Katajanokanranta"
+  },
+  {
+    "uid": "2e8fb1cf-1b61-4163-9156-abdb0dce3849",
+    "road": "Klaarantie"
+  },
+  {
+    "uid": "ec37b4dc-2025-49ec-9745-0eee567d158f",
+    "road": "Puolipäivänkatu",
+    "house_number": "4"
+  },
+  {
+    "uid": "359fb6ab-227f-4d59-b7e7-95a840cc7a7c",
+    "road": "Pohjoiskaari",
+    "house_number": "17"
+  },
+  {
+    "uid": "68051077-66a8-4308-9972-84da06bea491",
+    "road": "Pohjoiskaari",
+    "house_number": "21"
+  },
+  {
+    "uid": "9c03e90f-c8de-4854-b79c-0a07c7af69fc",
+    "road": "Pohjoiskaari",
+    "house_number": "27"
+  },
+  {
+    "uid": "e7fbe0d3-f9eb-4609-9cc8-0cc63257a4ce",
+    "road": "Merisotilaankatu",
+    "house_number": "3"
+  },
+  {
+    "uid": "7ee38ab5-c8d3-49ac-9873-9af004354ff9",
+    "road": "Pohjoiskaari",
+    "house_number": "35"
+  },
+  {
+    "uid": "1ddade2a-0ef4-4e43-b278-b6ed5a78da7b",
+    "road": "Merisotilaankatu",
+    "house_number": "2"
+  },
+  {
+    "uid": "3a04778d-6755-413b-b108-5862f9a90665",
+    "road": "Maamonlahdentie",
+    "house_number": "1"
+  },
+  {
+    "uid": "ba6976dd-e771-46e1-9b82-1cd177997cd6",
+    "road": "Pohjoiskaari",
+    "house_number": "39"
+  },
+  {
+    "uid": "cb879452-07e5-43cc-a628-d42b923964b3",
+    "road": "Klaarantie",
+    "house_number": "4"
+  },
+  {
+    "uid": "72207837-d94f-4cc1-9980-a97903164022",
+    "road": "Pohjoisniementie",
+    "house_number": "5 D"
+  },
+  {
+    "uid": "a29b4ec9-f787-4803-b9e0-4068bc32c499",
+    "road": "Merisotilaantori",
+    "house_number": "3"
+  },
+  {
+    "uid": "ff9435e0-ff01-4e91-af94-6505e8a868a6",
+    "road": "Merikasarminkatu",
+    "house_number": "7"
+  },
+  {
+    "uid": "548d77bf-e840-4953-9f57-186d43953fc2",
+    "road": "Merikasarminkatu",
+    "house_number": "16"
+  },
+  {
+    "uid": "c58351c4-5a4f-4eb3-84bf-226f23240411",
+    "road": "Katajanokanranta",
+    "house_number": "21"
+  },
+  {
+    "uid": "5e44573b-135b-4d64-b70f-4eb8b7bb627d",
+    "road": "Katajanokanranta",
+    "house_number": "21"
+  },
+  {
+    "uid": "231be758-b687-4791-87bf-c8437ae1e30f",
+    "road": "Matruusinkatu",
+    "house_number": "3"
+  },
+  {
+    "uid": "b3caf06d-9b81-431b-bf8d-b92f7e881490",
+    "road": "Matruusinkatu"
+  },
+  {
+    "uid": "fb25b91f-63f7-42f4-a3f1-6fe297d74166",
+    "road": "Amiraalinkatu",
+    "house_number": "2"
+  },
+  {
+    "uid": "47c4ef5c-d2dc-4ef6-a9fa-c44ab9e7fd04",
+    "road": "Klaarantie",
+    "house_number": "5"
+  },
+  {
+    "uid": "73facd18-f1a9-4922-8afb-cfe89234e51b",
+    "road": "Lauttasaarentie",
+    "house_number": "7"
+  },
+  {
+    "uid": "a88b58be-c3e3-475a-ac82-3903b647860e",
+    "road": "Puolipäivänkatu",
+    "house_number": "4"
+  },
+  {
+    "uid": "767d2367-7573-4f28-a414-08a3748488f5"
+  },
+  {
+    "uid": "e84b3dba-01a5-4b63-a704-9390c6880644",
+    "road": "Koillisväylä",
+    "house_number": "17"
+  },
+  {
+    "uid": "89b1e9fc-7cf9-4455-99e8-6ecb4b769be0",
+    "road": "Merikasarminkatu"
+  },
+  {
+    "uid": "b2f16526-da66-4f13-9ac5-48623dff0ce0",
+    "road": "Koillisväylä"
+  },
+  {
+    "uid": "376654da-a7f4-41b4-82c3-cd708e8fa8f5",
+    "road": "Linnankatu",
+    "house_number": "4"
+  },
+  {
+    "uid": "c4c5ff39-3683-4a63-b8ef-d5758c34ab62",
+    "road": "Koillisväylä",
+    "house_number": "8"
+  },
+  {
+    "uid": "9259c645-48dc-4d5c-b7e0-f714e226f1d9",
+    "road": "Lielahdentie",
+    "house_number": "7a"
+  },
+  {
+    "uid": "3e37389d-53f2-45bc-b4a7-8a1f7ba9790e",
+    "road": "Linnankatu"
+  },
+  {
+    "uid": "72fc47f1-d35e-4a75-8b5c-4513664fcd46",
+    "road": "Lauttasaarentie",
+    "house_number": "5b"
+  },
+  {
+    "uid": "3b919c77-9426-4b3c-b00f-e915c3695a58",
+    "road": "Lauttasaarentie",
+    "house_number": "12"
+  },
+  {
+    "uid": "f0e55b17-7534-4558-8761-4592688b4827",
+    "road": "Lauttasaarentie",
+    "house_number": "11"
+  },
+  {
+    "uid": "186a5ef4-6a8f-4907-9ed9-388c6f17cbc9",
+    "road": "Lauttasaarentie",
+    "house_number": "16"
+  },
+  {
+    "uid": "0b39f744-2389-4f44-bc0b-01fd2cba8fe8",
+    "road": "Lauttasaarentie"
+  },
+  {
+    "uid": "a903695b-bf37-4abc-a886-8545897a0c33",
+    "road": "Taivaanvuohentie",
+    "house_number": "3"
+  },
+  {
+    "uid": "dfc4e55d-7863-4ba0-ad4f-a30199c65c49",
+    "road": "Laivastokatu"
+  },
+  {
+    "uid": "c6d81030-c36a-44c4-ab2a-25a97213f45d",
+    "road": "Taivaanvuohentie",
+    "house_number": "9"
+  },
+  {
+    "uid": "29bf6e15-fafa-41e1-bf29-d5d5218c3b5a",
+    "road": "Taivaanvuohentie",
+    "house_number": "10"
+  },
+  {
+    "uid": "f7f126be-a3fb-40f7-a0f5-b367d2d2e0f0",
+    "road": "Taivaanvuohentie",
+    "house_number": "12"
+  },
+  {
+    "uid": "3d6d8ede-1d8c-4a4e-a638-c63798928e7d",
+    "road": "Kruunuvuorenkatu"
+  },
+  {
+    "uid": "2e28157f-00e3-4053-82c9-fe448fdb9763",
+    "road": "Kruunuvuorenkatu"
+  },
+  {
+    "uid": "6333c516-54b0-489e-98e4-629490b7a912",
+    "road": "Linnankatu"
+  },
+  {
+    "uid": "df6a9b56-c2a7-4412-98fc-d1431c795918",
+    "road": "Merikasarminkatu",
+    "house_number": "2"
+  },
+  {
+    "uid": "fdf1f267-31a0-48c0-b424-b2d4e20e3021",
+    "road": "Laivastokatu",
+    "house_number": "22"
+  },
+  {
+    "uid": "1b734657-6280-4de3-bdee-c44014d578b4",
+    "road": "Laivastokatu",
+    "house_number": "22"
+  },
+  {
+    "uid": "475efacd-4246-44f2-9e04-6ed42fa5c8d2",
+    "road": "Laivastokatu",
+    "house_number": "8-10"
+  },
+  {
+    "uid": "e86b55ed-a444-4d4c-b28c-7b61c70ef562",
+    "road": "Gyldénintie"
+  },
+  {
+    "uid": "a4201829-31b7-4b73-87e3-031873b2dacf",
+    "road": "Laivastokatu"
+  },
+  {
+    "uid": "dd2f7db2-bd4f-4d7f-89ff-f05776b67cc2",
+    "road": "Gyldénintie",
+    "house_number": "12"
+  },
+  {
+    "uid": "0701080b-9834-4b28-89dd-eacc532b26f2",
+    "road": "Gyldénintie",
+    "house_number": "12"
+  },
+  {
+    "uid": "4ad44157-ed41-4530-bb6d-1bc3b648050c",
+    "road": "Gyldénintie",
+    "house_number": "12"
+  },
+  {
+    "uid": "57a6700b-3ec4-4827-8eb0-de5f598cf31c",
+    "road": "Gyldénintie"
+  },
+  {
+    "uid": "4384e646-63df-4b86-8ca3-2655f5f86083",
+    "road": "Laivastokatu"
+  },
+  {
+    "uid": "a3ca399e-62fc-40ae-bb6d-e5dbc1cea5ec",
+    "road": "Laivastokatu"
+  },
+  {
+    "uid": "0cd36f07-8b68-4387-bb0f-9c523d836eb3",
+    "road": "Lielahdentie"
+  },
+  {
+    "uid": "7cdb58b8-7fa3-4e4c-b71d-8a10e8043b76",
+    "road": "Laivastokatu",
+    "house_number": "4"
+  },
+  {
+    "uid": "f50c8bb7-e16b-4121-8d5d-6f88b4d645fd",
+    "road": "Gyldénintie",
+    "house_number": "8"
+  },
+  {
+    "uid": "536736c9-a98b-4ca8-84fc-6e8f6fc2fe4c",
+    "road": "Laivastokatu",
+    "house_number": "12"
+  },
+  {
+    "uid": "beaef5f8-2f9d-4311-8525-bff40e1af440",
+    "road": "Laivastokatu"
+  },
+  {
+    "uid": "d73b49d5-babc-4ce0-81bf-f804f0831b22",
+    "road": "Laivastokatu",
+    "house_number": "12"
+  },
+  {
+    "uid": "0af51c3b-baf7-4e8d-aa1f-10ff5f4ba8b7",
+    "road": "Laivastokatu"
+  },
+  {
+    "uid": "64daad08-d839-4ceb-8521-deed2fcc1731",
+    "road": "Lielahdentie",
+    "house_number": "2"
+  },
+  {
+    "uid": "27422252-1d1a-4e82-95a2-3e8204280503",
+    "road": "Vyökatu",
+    "house_number": "9"
+  },
+  {
+    "uid": "cc6c8c3a-d623-4b13-b4d9-bbcde0765700",
+    "road": "Luotsikatu"
+  },
+  {
+    "uid": "67923a53-f8c4-43d5-921c-7eced669eb44",
+    "road": "Vyökatu",
+    "house_number": "5"
+  },
+  {
+    "uid": "4eb40254-5bcb-4be0-9411-dd78396d7f4f",
+    "road": "Vyökatu",
+    "house_number": "4"
+  },
+  {
+    "uid": "da2d5b9e-e528-44f0-bb93-1642a330dd5f",
+    "road": "Hakolahdentie",
+    "house_number": "1"
+  },
+  {
+    "uid": "42763fc2-ba3f-41de-8508-9d9482fb3547",
+    "road": "Hakolahdentie",
+    "house_number": "1"
+  },
+  {
+    "uid": "f0d9db83-2d92-4a7c-b35f-fc4c29cf7f9a",
+    "road": "Vyökatu"
+  },
+  {
+    "uid": "2540f0a6-ab24-450b-be8f-b30e481d32bb",
+    "road": "Myllykallionrinne",
+    "house_number": "2"
+  },
+  {
+    "uid": "db2b3b19-5f3f-4ea8-9a94-22081b9581ea",
+    "road": "Kauppiaankatu"
+  },
+  {
+    "uid": "bd419588-bc9f-46f1-b99c-a707fc1b8d98",
+    "road": "Kauppiaankatu"
+  },
+  {
+    "uid": "259b9614-185e-4c8d-af93-af0aede094a4",
+    "road": "Kruunuvuorenkatu"
+  },
+  {
+    "uid": "b804a4cc-eda0-42ea-b432-4a8aa73b4646",
+    "road": "Kauppiaankatu",
+    "house_number": "1"
+  },
+  {
+    "uid": "5262c65d-94d5-4f77-979c-49a7c56a734f",
+    "road": "Linnankatu",
+    "house_number": "3"
+  },
+  {
+    "uid": "d6d671d5-9b64-4cf4-9508-e2d450e56782",
+    "road": "Hakolahdentie",
+    "house_number": "1"
+  },
+  {
+    "uid": "c0c010ea-76c8-4d51-98c6-e5a69d10bc35",
+    "road": "Kruunuvuorenkatu"
+  },
+  {
+    "uid": "7d4e4967-cc72-4d13-8297-e78c207cfc02",
+    "road": "Kruunuvuorenkatu",
+    "house_number": "3"
+  },
+  {
+    "uid": "0b2876ba-024e-4a87-a03b-c8009540a2ef",
+    "road": "Hakolahdentie",
+    "house_number": "1"
+  },
+  {
+    "uid": "dbe4f393-c92d-4f07-b1e2-0dcd1d4dd217",
+    "road": "Kuikkarinne",
+    "house_number": "4"
+  },
+  {
+    "uid": "47b3472a-b5c9-4d99-9f79-666628429a73",
+    "road": "Kajavatie",
+    "house_number": "2"
+  },
+  {
+    "uid": "16ae9b4a-a015-402c-a4f9-34b0bec9ef41",
+    "road": "Tiirasaarentie",
+    "house_number": "6a"
+  },
+  {
+    "uid": "899fa12a-b137-44bb-b07e-c4a5bbaa1a3a",
+    "road": "Tiirasaarentie",
+    "house_number": "21"
+  },
+  {
+    "uid": "15ad719b-2fdb-475d-b7ec-40adcb485138",
+    "road": "Hakolahdentie",
+    "house_number": "7"
+  },
+  {
+    "uid": "1eb3c130-f5eb-45c3-8103-002ec20dc3d2",
+    "road": "Hakolahdentie",
+    "house_number": "18"
+  },
+  {
+    "uid": "56d174f7-bf90-426c-ac7a-a420d678c060",
+    "road": "Satamakatu",
+    "house_number": "2"
+  },
+  {
+    "uid": "804c15bd-1c20-4484-b6ba-78054afab550",
+    "road": "Hakolahdentie",
+    "house_number": "27"
+  },
+  {
+    "uid": "4ea8d28c-f16b-4f8a-bd71-5be406e66331",
+    "road": "Kajavatie",
+    "house_number": "10"
+  },
+  {
+    "uid": "b6d03f34-6d5f-4c31-a67e-528d1ac8cab4",
+    "road": "Takaniementie",
+    "house_number": "4"
+  },
+  {
+    "uid": "25f08b2e-a19d-41f7-913d-b9a5650f87eb",
+    "road": "Kyyluodontie",
+    "house_number": "7"
+  },
+  {
+    "uid": "142b20ef-f4f7-4b8e-a3f1-9728c7ef1e4a",
+    "road": "Kuikkarinne"
+  },
+  {
+    "uid": "d5e8fecd-1161-4e1e-8f98-555079aa85ad",
+    "road": "Kajavatie",
+    "house_number": "10"
+  },
+  {
+    "uid": "461d7726-9dd3-4a31-95ef-7e5f513e709f",
+    "road": "Takaniementie"
+  },
+  {
+    "uid": "2b690032-6011-437f-9e00-e0bfba455bca",
+    "road": "Tiirasaarentie",
+    "house_number": "31"
+  },
+  {
+    "uid": "643cb6c2-c122-4bfa-afe1-3844f870c203",
+    "road": "Hakolahdenkuja",
+    "house_number": "4"
+  },
+  {
+    "uid": "12ed684e-11a5-489f-8c1c-3ed95adcea1e",
+    "road": "Luotsikatu"
+  },
+  {
+    "uid": "a1e74844-ad93-48e6-bdbe-a69a14b2993d",
+    "road": "Luotsikatu"
+  },
+  {
+    "uid": "795194e5-417f-4e33-964c-550246d9e1fd",
+    "road": "Luotsikatu",
+    "house_number": "12"
+  },
+  {
+    "uid": "27bca9f7-3f41-4784-b9fc-fcd671f5d472",
+    "road": "Lounaisväylä",
+    "house_number": "12"
+  },
+  {
+    "uid": "36b7bf21-7844-4f57-bf12-fbcb6103730c",
+    "road": "Kaisaniemen puistokuja"
+  },
+  {
+    "uid": "dd17116b-0ea0-4e73-b459-f586b4a9ff43",
+    "road": "Lounaisväylä",
+    "house_number": "10"
+  },
+  {
+    "uid": "3a2359b5-ae07-4271-84e9-74030c099ee7",
+    "road": "Tiirasaarentie",
+    "house_number": "30"
+  },
+  {
+    "uid": "c70801e9-a378-44d2-a5b5-8e7e3ee36297",
+    "road": "Laivastokatu"
+  },
+  {
+    "uid": "d639046c-97b7-47c2-aba8-c7062e109e28",
+    "road": "Lentokapteenin kuja",
+    "house_number": "4"
+  },
+  {
+    "uid": "e28a8714-6726-4758-9026-1bae7b511685",
+    "road": "Lounaisväylä",
+    "house_number": "2"
+  },
+  {
+    "uid": "9b1b69e3-082b-4c2d-95dc-26371635bdd8",
+    "road": "Satamakatu",
+    "house_number": "5"
+  },
+  {
+    "uid": "ad42a25e-c629-41bd-b040-de1d4645ef7f",
+    "road": "Kruunuvuorenkatu"
+  },
+  {
+    "uid": "36d1cdc9-3fa9-4b06-bb0e-ab4aec64eff2",
+    "road": "Lounaisväylä",
+    "house_number": "4"
+  },
+  {
+    "uid": "fbb2a17b-97fd-4dcf-8b3e-bdcb1988e9d7",
+    "road": "Luotsikatu",
+    "house_number": "3"
+  },
+  {
+    "uid": "89ea67b4-0e8a-4f25-96d8-1d0b1937512a",
+    "road": "Luotsikatu",
+    "house_number": "4"
+  },
+  {
+    "uid": "cf738cd3-984e-409b-b728-e044cc6298f6",
+    "road": "Katajanokankatu",
+    "house_number": "7"
+  },
+  {
+    "uid": "d76b805d-b575-4bf5-b957-5815b8563430",
+    "road": "Laivastokatu"
+  },
+  {
+    "uid": "dfb52dc5-8b2f-483d-81da-62c591c7f9ba",
+    "road": "Ankkurikatu",
+    "house_number": "5"
+  },
+  {
+    "uid": "e4d9a726-904a-4b20-a9c7-e317313dce04",
+    "road": "Ankkurikatu"
+  },
+  {
+    "uid": "0033d2f8-e0cc-4407-9ed1-9f573917f47a",
+    "road": "Ankkurikatu"
+  },
+  {
+    "uid": "8bd4e749-4ebc-423d-8178-c10830e26728",
+    "road": "Ankkurikatu"
+  },
+  {
+    "uid": "dce73a21-389c-466c-99db-15c100a56482",
+    "road": "Kanavakatu",
+    "house_number": "3"
+  },
+  {
+    "uid": "608bb292-8025-4a78-bdea-01beacfa250e",
+    "road": "Ruukinlahdentie"
+  },
+  {
+    "uid": "5626fef4-7894-46aa-885d-218ea8b2dc6d",
+    "road": "Lahnaruohontie",
+    "house_number": "7"
+  },
+  {
+    "uid": "74763bec-f729-48b2-8f79-b7f5fe26ae92",
+    "road": "Myllykallionrinne",
+    "house_number": "2"
+  },
+  {
+    "uid": "09ed14ed-64bc-4d80-b218-f22432836eb4",
+    "road": "Satamakatu",
+    "house_number": "3"
+  },
+  {
+    "uid": "152cfb20-01d6-454c-9022-442694ea8281",
+    "road": "Kanavakatu",
+    "house_number": "1"
+  },
+  {
+    "uid": "449071a0-1a64-46ea-b1ef-8b690d9e5f52",
+    "road": "Kanavakatu"
+  },
+  {
+    "uid": "78ac1994-b458-48c6-9f54-a5375944ecb5",
+    "road": "Kanavakatu"
+  },
+  {
+    "uid": "882c3059-0488-4f6f-9fa7-ebf433445429",
+    "road": "Ankkurikatu"
+  },
+  {
+    "uid": "daa6bfb7-ad88-461b-90b8-1153c36228f1",
+    "road": "Katajanokanlaituri",
+    "house_number": "6"
+  },
+  {
+    "uid": "ba7bd99c-5cf0-445b-9e69-d5747b794be6",
+    "road": "Myllykallionrinne",
+    "house_number": "2"
+  },
+  {
+    "uid": "fccd32cb-ae42-4b1b-a0f2-a7e5f38f39af",
+    "road": "Lahnaruohontie",
+    "house_number": "1"
+  },
+  {
+    "uid": "33daab1b-fd88-49b3-9f21-13af43a56bcb",
+    "road": "Myllykalliontie",
+    "house_number": "6"
+  },
+  {
+    "uid": "9ca862c8-c64c-4ca5-9228-7fc513879729",
+    "road": "Myllykalliontie",
+    "house_number": "3 C"
+  },
+  {
+    "uid": "2904cfdc-c306-4b8c-ba1a-badfe550946a",
+    "road": "Myllykalliontie",
+    "house_number": "6"
+  },
+  {
+    "uid": "29ed86aa-2d10-42bb-beb3-600fb3aeba87",
+    "road": "Myllykalliontie"
+  },
+  {
+    "uid": "bc8ff8cf-bc74-4070-8dd0-46f4068126e5",
+    "road": "Sotkatie"
+  },
+  {
+    "uid": "6367d754-a49f-4732-8a78-511854b453ef",
+    "road": "Isokaari"
+  },
+  {
+    "uid": "43cc8e00-373e-4994-a87b-aadb89c3368e",
+    "road": "Isokaari",
+    "house_number": "12"
+  },
+  {
+    "uid": "4fe97250-3cd0-4862-ba78-b83921362b54",
+    "road": "Isokaari",
+    "house_number": "18"
+  },
+  {
+    "uid": "d9a5c0b1-15ab-49bd-bdf0-433badaefc02",
+    "road": "Isokaari",
+    "house_number": "20"
+  },
+  {
+    "uid": "34154555-bda7-448e-b8a7-064f36af35bc",
+    "road": "Isokaari",
+    "house_number": "16"
+  },
+  {
+    "uid": "4e026cd8-2578-4a43-a68c-719b60ee92c0",
+    "road": "Isokaari"
+  },
+  {
+    "uid": "c646b5cf-58ca-431f-8b01-a76f82519cbf",
+    "road": "Isokaari",
+    "house_number": "24"
+  },
+  {
+    "uid": "b898e51a-07da-409e-bdb6-da0591d44714",
+    "road": "Isokaari",
+    "house_number": "28"
+  },
+  {
+    "uid": "f2b1e90b-ce6b-4b4b-a356-489ce93a1787",
+    "road": "Isokaari",
+    "house_number": "30"
+  },
+  {
+    "uid": "7cb7e536-f9e6-4da2-8dac-c16fb5aa78de",
+    "road": "Viklakuja",
+    "house_number": "1"
+  },
+  {
+    "uid": "cdedd078-a893-462a-aad3-f245a5dbcc62",
+    "road": "Viklakuja",
+    "house_number": "5"
+  },
+  {
+    "uid": "d2a8364d-1f2e-48db-ad59-8448eae8ddc3",
+    "road": "Lounaisväylä",
+    "house_number": "12"
+  },
+  {
+    "uid": "cf209d33-5478-4412-ab98-dad4a81bd8c4",
+    "road": "Puistokaari"
+  },
+  {
+    "uid": "cf665d5d-129e-44cc-8625-40f0fdd4338c",
+    "road": "Puistokaari",
+    "house_number": "9"
+  },
+  {
+    "uid": "ba06fa93-a3a1-4231-9c0e-1ad822cf568b",
+    "road": "Puistokaari"
+  },
+  {
+    "uid": "ed202c96-7aa3-4f3a-b6cb-48f6b8af6cf9",
+    "road": "Puistokaari"
+  },
+  {
+    "uid": "f6d2c41d-48e0-41d4-9b62-824fe32846f6",
+    "road": "Puistokaari",
+    "house_number": "12"
+  },
+  {
+    "uid": "ae8d4be6-4de4-4e63-a3c0-acadd4711f3e",
+    "road": "Puistokaari",
+    "house_number": "17"
+  },
+  {
+    "uid": "9e3ce098-1470-437d-acff-7d4a53a8496c",
+    "road": "Isokaari",
+    "house_number": "34"
+  },
+  {
+    "uid": "00a59f2b-2e6c-4350-8b9a-8b06cdcfb3a0",
+    "road": "Isokaari",
+    "house_number": "40"
+  },
+  {
+    "uid": "671d69c4-1e7d-40c4-83e1-549fc91c9fb5",
+    "road": "Isokaari",
+    "house_number": "42"
+  },
+  {
+    "uid": "3aed7e06-3255-442f-9c0f-1715fe20aeb6",
+    "road": "Isokaari",
+    "house_number": "40"
+  },
+  {
+    "uid": "2fa00807-e435-4a87-9ae7-8355db33ed94",
+    "road": "Lauttasaarentie"
+  },
+  {
+    "uid": "ef748a49-fdac-4a1d-8a56-588faa574159",
+    "road": "Lauttasaarentie"
+  },
+  {
+    "uid": "31e4140e-1f0d-4638-a5d5-59e44001cd33",
+    "road": "Lauttasaarentie",
+    "house_number": "50"
+  },
+  {
+    "uid": "4ec88f6b-d057-4b6c-b84b-054b20efe8a0",
+    "road": "Lokkikuja",
+    "house_number": "1"
+  },
+  {
+    "uid": "17845922-2525-4852-8d94-7260bd573f58",
+    "road": "Kaakkurikuja"
+  },
+  {
+    "uid": "a52f9b7b-17e3-4544-8cdd-ae702885885b",
+    "road": "Kaakkurikuja",
+    "house_number": "4"
+  },
+  {
+    "uid": "4803699b-4f4d-4c7e-a8ee-1e50fa7b395f",
+    "road": "Lokkikuja",
+    "house_number": "1"
+  },
+  {
+    "uid": "3405e24f-aa69-4af3-8909-3ea86bbef4ae",
+    "road": "Lokkikuja",
+    "house_number": "5"
+  },
+  {
+    "uid": "92d2b3f5-ad10-4e2c-8faa-d12badf5de39",
+    "road": "Vaskiniementie"
+  },
+  {
+    "uid": "c1e01ad4-6931-40ad-8c5d-6446a91933cd",
+    "road": "Isokaari"
+  },
+  {
+    "uid": "b2868cc3-ce00-430e-a116-36fc72521627",
+    "road": "Isokaari"
+  },
+  {
+    "uid": "12becfce-4cb7-4b03-94a1-6a3e5d7f138b",
+    "road": "Isokaari"
+  },
+  {
+    "uid": "f4858c0d-f28f-4455-88a1-8b3f873b0cbd",
+    "road": "Sotkatie"
+  },
+  {
+    "uid": "52be66a8-8253-4219-886b-88f165244a98",
+    "road": "Lahnalahdentie"
+  },
+  {
+    "uid": "033f2045-c7ff-44f7-b2a4-2ca5347a3a94",
+    "road": "Lahnalahdentie"
+  },
+  {
+    "uid": "662fb9cf-3550-4ed9-9fc3-2b709c68b6bd",
+    "road": "Lauttasaarentie",
+    "house_number": "50 e (2.krs.)"
+  },
+  {
+    "uid": "c5e19383-a996-4a2a-9158-236ae7024d7b",
+    "road": "Lauttasaarentie",
+    "house_number": "50 e (2.krs.)"
+  },
+  {
+    "uid": "5afb4dae-b12a-454b-b1a3-e694afe34024",
+    "road": "Lauttasaarenmäki",
+    "house_number": "5"
+  },
+  {
+    "uid": "a1dab84e-3c65-4afc-acba-48b801fe59ae",
+    "road": "Lahnalahdentie",
+    "house_number": "4"
+  },
+  {
+    "uid": "f2825eba-6d19-476c-926a-9ec5e4dc8598",
+    "road": "Luoteisväylä",
+    "house_number": "3 A"
+  },
+  {
+    "uid": "559b3f78-4034-42d6-8c89-e5915bef6a76",
+    "road": "Koivusaarentie",
+    "house_number": "2"
+  },
+  {
+    "uid": "2cde9d31-d77d-406b-b654-7d0a41e18e84",
+    "road": "Luoteisväylä",
+    "house_number": "13"
+  },
+  {
+    "uid": "930f013a-426c-4041-b470-b6da4c4c8f5a",
+    "road": "Luoteisväylä",
+    "house_number": "21"
+  },
+  {
+    "uid": "77eacd6b-819b-403f-b8c7-fc0faa251252",
+    "road": "Laukkaniementie"
+  },
+  {
+    "uid": "3c5bec4a-a665-423e-9da3-37ebfe773242",
+    "road": "Luoteisväylä",
+    "house_number": "32"
+  },
+  {
+    "uid": "c741ece4-93d8-474a-aff2-2367affe522c",
+    "road": "Katajaharjuntie",
+    "house_number": "22 F"
+  },
+  {
+    "uid": "bb98c85c-5117-40bb-882d-753f9431ad14",
+    "road": "Katajaharjuntie",
+    "house_number": "15"
+  },
+  {
+    "uid": "3649cd2d-bfb6-4187-94a9-b9f97797b78f",
+    "road": "Katajaharjuntie",
+    "house_number": "1"
+  },
+  {
+    "uid": "58145ba9-3d3e-472f-bb8d-bdc543690fd7",
+    "road": "Katajaharjuntie",
+    "house_number": "7-9"
+  },
+  {
+    "uid": "101bc917-8aae-4cf3-abd3-4722de7453f9",
+    "road": "Telkkäkuja",
+    "house_number": "4"
+  },
+  {
+    "uid": "cbaa2d36-7364-4320-89fe-51cb5f2ae8f3",
+    "road": "Telkkäkuja",
+    "house_number": "3"
+  },
+  {
+    "uid": "b893dff0-a462-4b93-bb2a-40695fda69f0",
+    "road": "Telkkäkuja",
+    "house_number": "5"
+  },
+  {
+    "uid": "2aa43a9d-83c7-49f9-bd63-fdf2944daf71",
+    "road": "Telkkäkuja",
+    "house_number": "7"
+  },
+  {
+    "uid": "ba41603e-e22d-4481-9012-347fa89ae69e",
+    "road": "Telkkäkuja",
+    "house_number": "9"
+  },
+  {
+    "uid": "18c2d36b-b084-4675-80da-3333a80e3d10",
+    "road": "Koivusaarentie",
+    "house_number": "14"
+  },
+  {
+    "uid": "3929ef48-74db-4a98-b874-9c9d96dbc681",
+    "road": "Koivusaarentie",
+    "house_number": "10"
+  },
+  {
+    "uid": "8b449390-96de-4436-a192-82160cff4dad",
+    "road": "Tallberginkatu",
+    "house_number": "1"
+  },
+  {
+    "uid": "1d1f409f-72c3-4fda-9459-883cb098e719",
+    "road": "Meritullinkatu",
+    "house_number": "10"
+  },
+  {
+    "uid": "4a295752-5f66-46f1-8945-383e92843f8a",
+    "road": "Katajanokanlaituri"
+  },
+  {
+    "uid": "dc97c999-fff2-4225-8fc9-c9f2f5b6f73c",
+    "road": "Katajanokanlaituri",
+    "house_number": "4"
+  },
+  {
+    "uid": "db733c80-5089-4777-aa27-f5fb6a7f3931",
+    "road": "Katajanokanlaituri"
+  },
+  {
+    "uid": "ffa17091-9390-47fc-8a7f-4c202d8a8727",
+    "road": "Katajanokanlaituri"
+  },
+  {
+    "uid": "947adf14-bbb4-42ce-8047-ebfd4dde648c",
+    "road": "Satamakatu"
+  },
+  {
+    "uid": "23d60e65-10ca-4393-a305-3cde18a50954",
+    "road": "Rahapajankatu"
+  },
+  {
+    "uid": "7a42ac22-2a5f-4579-b979-bbc8c941a1d6",
+    "road": "Rahapajankatu"
+  },
+  {
+    "uid": "c4118ba5-f0fa-4c1c-94d3-3a6890b30221",
+    "road": "Katajanokanlaituri"
+  },
+  {
+    "uid": "9edd5d3b-7d0b-4417-ab67-841893d23afc",
+    "road": "Pormestarinrinne"
+  },
+  {
+    "uid": "72f34db5-a451-4d39-89bd-51083854738c",
+    "road": "Pormestarinrinne",
+    "house_number": "2"
+  },
+  {
+    "uid": "340e38d4-c6c9-4eab-85b3-8432e6b48953",
+    "road": "Pormestarinrinne",
+    "house_number": "6"
+  },
+  {
+    "uid": "3d59e981-8e9b-4ddb-bde4-dc46702e7e88",
+    "road": "Kanavaranta"
+  },
+  {
+    "uid": "7fe24b43-7149-439a-b1cf-6f9300c06859",
+    "road": "Porkkalankatu",
+    "house_number": "50"
+  },
+  {
+    "uid": "b20000e6-9a04-4746-a250-ab4647df1ec8",
+    "road": "Porkkalankatu",
+    "house_number": "50"
+  },
+  {
+    "uid": "739d5553-050a-433c-8b2c-2e39c476b089",
+    "road": "Tammasaarenlaituri",
+    "house_number": "3"
+  },
+  {
+    "uid": "a47bc259-00eb-46ac-9b0b-11062deaf894",
+    "road": "Tallberginkatu",
+    "house_number": "1"
+  },
+  {
+    "uid": "4affe744-368b-4031-93c9-3f8e0a59b2bf",
+    "road": "Tallberginkatu",
+    "house_number": "3"
+  },
+  {
+    "uid": "de737dd3-1218-4a03-b9e5-6bc22452c53e",
+    "road": "Mariankatu",
+    "house_number": "3"
+  },
+  {
+    "uid": "8b9d27ae-fe6e-4980-89ba-c9bd46bba9bc",
+    "road": "Hallituskatu"
+  },
+  {
+    "uid": "33b3efe8-75f3-4afa-99c4-7a3bca826cc9",
+    "road": "Mariankatu"
+  },
+  {
+    "uid": "77655223-8743-458a-a275-8eb7a7528f6a",
+    "road": "Mariankatu",
+    "house_number": "11"
+  },
+  {
+    "uid": "0127b576-6f5b-4ddb-9b9c-0117868b4126",
+    "road": "Kirkkokatu"
+  },
+  {
+    "uid": "afcbb7d1-9316-4f90-a1df-603ecbc07dbc",
+    "road": "Rauhankatu"
+  },
+  {
+    "uid": "b302f1ca-c922-42aa-8ba7-681a8b27a1f6",
+    "road": "Rauhankatu"
+  },
+  {
+    "uid": "971dc54b-a883-40b2-af01-bc1505a3261a",
+    "road": "Vironkatu"
+  },
+  {
+    "uid": "41922d40-7d6c-40a5-bbc1-ebb56ae6ecc4",
+    "road": "Mariankatu",
+    "house_number": "19"
+  },
+  {
+    "uid": "e3703540-ca2d-4d14-9d52-148681fc70d3",
+    "road": "Mariankatu"
+  },
+  {
+    "uid": "4f706761-3e23-4f48-865e-d519491d5077",
+    "road": "Mariankatu"
+  },
+  {
+    "uid": "1262822d-e62a-4c28-b1f8-0ba63c9e2803",
+    "road": "Mariankatu",
+    "house_number": "23"
+  },
+  {
+    "uid": "5c9a0054-49ce-4cc2-b9f3-3ee2b707e0f9",
+    "road": "Liisankatu"
+  },
+  {
+    "uid": "18432b9a-aace-4d5d-bc17-aee6d026f360",
+    "road": "Meritullinkatu"
+  },
+  {
+    "uid": "46ea359c-c0e7-4082-86f0-f1028bd8dbef",
+    "road": "Meritullinkatu"
+  },
+  {
+    "uid": "8d418b9d-80ec-48cb-ad30-da1c163ab2e5",
+    "road": "Porkkalankatu"
+  },
+  {
+    "uid": "2e0562b8-f998-4bf4-9a66-1105f5daaf14",
+    "road": "Salmisaarenranta"
+  },
+  {
+    "uid": "269be69a-4930-482a-a04d-266196adc305",
+    "road": "Salmisaarenranta"
+  },
+  {
+    "uid": "8cac1845-9b33-478f-8f09-9e478a5612b2",
+    "road": "Salmisaarenranta"
+  },
+  {
+    "uid": "78f89f68-6919-4726-b907-426549352e05",
+    "road": "Tammasaarenkatu"
+  },
+  {
+    "uid": "9813e23a-e56a-43b1-bdb8-f14e379caf6e",
+    "road": "Kaapeliaukio"
+  },
+  {
+    "uid": "d1c36ad5-c4c2-4f50-a170-c8db6c2cc89f",
+    "road": "Meritullinkatu"
+  },
+  {
+    "uid": "74c66b9d-9a53-4805-bc5d-4f4582203516",
+    "road": "Meritullinkatu",
+    "house_number": "8"
+  },
+  {
+    "uid": "64db9cb5-0f2e-42a2-a4a9-7cfae8d75100",
+    "road": "Meritullinkatu",
+    "house_number": "6"
+  },
+  {
+    "uid": "05e838fe-d6cd-438e-8510-7b02fc6f9160",
+    "road": "Kirkkokatu"
+  },
+  {
+    "uid": "ea0135c8-89c1-4ece-8c0a-b1196b0db9f5",
+    "road": "Harmajankatu",
+    "house_number": "2"
+  },
+  {
+    "uid": "40d70b1f-9d3e-495b-a1a8-e79d0bbbffec",
+    "road": "Kellosaarenranta",
+    "house_number": "2"
+  },
+  {
+    "uid": "2b0c3183-be03-4e9a-af97-ae7dff3f9041",
+    "road": "Kellosaarenranta",
+    "house_number": "1"
+  },
+  {
+    "uid": "b38aebd7-0558-448f-b600-2f14c29d1571",
+    "road": "Rauhankatu"
+  },
+  {
+    "uid": "f35699d4-6f44-4acb-bfe6-fa132d33faf8",
+    "road": "Rauhankatu"
+  },
+  {
+    "uid": "c5e2e8da-9664-4dfc-9747-85518009fad2",
+    "road": "Vironkatu",
+    "house_number": "2"
+  },
+  {
+    "uid": "fb10d047-3fc3-4bc3-83d4-68abf55deeea",
+    "road": "Meritullinkatu",
+    "house_number": "13"
+  },
+  {
+    "uid": "a0e17cc8-5bea-4190-9eef-18d4c1cba48e",
+    "road": "Meritullinkatu",
+    "house_number": "15"
+  },
+  {
+    "uid": "8b3f450b-e69d-47bc-b9c0-8e6e0d07eaec",
+    "road": "Maneesikatu"
+  },
+  {
+    "uid": "c4c5db57-3f79-4b20-a43c-c434ca745eee",
+    "road": "Maneesikatu"
+  },
+  {
+    "uid": "fb2e39ef-e969-461c-8da8-241db8d4559c",
+    "road": "Liisankatu",
+    "house_number": "9"
+  },
+  {
+    "uid": "3b08ce48-a908-47a9-b2c2-ec89d899bacf",
+    "road": "Meritullinkatu",
+    "house_number": "25"
+  },
+  {
+    "uid": "60595484-b9a7-4322-9b23-ab8b6562e12f",
+    "road": "Meritullinkatu",
+    "house_number": "26"
+  },
+  {
+    "uid": "cd7add01-782c-48a3-a632-fd74a28efa96",
+    "road": "Meritullinkatu",
+    "house_number": "29"
+  },
+  {
+    "uid": "4e0c4216-af79-4a72-a595-d03c78be7b2a",
+    "road": "Kellosaarenranta"
+  },
+  {
+    "uid": "4a91f7ec-ac61-4dd9-8d1d-a080363a3787",
+    "road": "Meritullinkatu",
+    "house_number": "28-30"
+  },
+  {
+    "uid": "c9a2cc69-7c39-4655-8acb-7aa59ef7a273",
+    "road": "Kellosaarenranta"
+  },
+  {
+    "uid": "cc0264c8-355f-42ca-bc2c-d41a33841cc7",
+    "road": "Kruununhaankatu",
+    "house_number": "4"
+  },
+  {
+    "uid": "5f6545d1-9f29-4932-a917-b877dc098527",
+    "road": "Kruununhaankatu",
+    "house_number": "3"
+  },
+  {
+    "uid": "f81f4feb-b9d5-4054-af86-713ef096489f",
+    "road": "Pohjoisranta",
+    "house_number": "2"
+  },
+  {
+    "uid": "631ef476-7a93-4c22-b4dc-2e4a563d81d4",
+    "road": "Pohjoisranta"
+  },
+  {
+    "uid": "ded97c4b-cda7-45fe-bb86-c9060d940d36",
+    "road": "Pohjoisranta"
+  },
+  {
+    "uid": "ebc4087d-b705-4488-be8e-ef8d1fb81578",
+    "road": "Pohjoisranta",
+    "house_number": "10"
+  },
+  {
+    "uid": "695ac268-7dc6-4012-b97b-d9eaba1e042f",
+    "road": "Pohjoisranta"
+  },
+  {
+    "uid": "749119c9-0b70-48fc-8ff1-c2d86bf1f268",
+    "road": "Pohjoisranta",
+    "house_number": "18"
+  },
+  {
+    "uid": "430c7124-ba91-44a7-9998-f0403f6801e4",
+    "road": "Harmajankatu"
+  },
+  {
+    "uid": "fad1ce0f-07f9-4ea2-8dff-2e11273a4275",
+    "road": "Harmajankatu",
+    "house_number": "2"
+  },
+  {
+    "uid": "ac4e1688-56f1-4972-810c-1fc7bae6dc7a",
+    "road": "Pohjoisranta",
+    "house_number": "18"
+  },
+  {
+    "uid": "b408babc-3b3f-46c0-8733-d0822c2986fa",
+    "road": "Länsisatamankatu"
+  },
+  {
+    "uid": "78877755-dc73-4a26-a03b-8483478b42e3",
+    "road": "Länsisatamankatu",
+    "house_number": "11"
+  },
+  {
+    "uid": "65ade417-c26d-4bb8-b8dd-9c734ff6ca2c",
+    "road": "Pohjoisranta",
+    "house_number": "14"
+  },
+  {
+    "uid": "c088be6b-df1d-48f2-8076-bea13e950040",
+    "road": "Länsisatamankatu",
+    "house_number": "4"
+  },
+  {
+    "uid": "78b75627-cae4-429a-8799-653647371f45",
+    "road": "Länsisatamankatu",
+    "house_number": "5"
+  },
+  {
+    "uid": "0aacdfb0-eb65-494e-a3d6-b077d245dc2e",
+    "road": "Maneesikatu",
+    "house_number": "2"
+  },
+  {
+    "uid": "cffbc9f5-5177-4002-8e82-e0ffd590ba47",
+    "road": "Itämerenkatu",
+    "house_number": "23"
+  },
+  {
+    "uid": "aa4bf198-9632-4f03-b0ee-c42d9c836c87",
+    "road": "Maneesikatu",
+    "house_number": "2"
+  },
+  {
+    "uid": "a9a7478f-b683-45bf-bffd-593e43887ff2",
+    "road": "Itämerenkatu",
+    "house_number": "30"
+  },
+  {
+    "uid": "1e6da1d5-d795-4864-974e-698d631504ab",
+    "road": "Maneesikatu"
+  },
+  {
+    "uid": "0b74beba-21f5-4dd0-9da1-619200ccbe9f",
+    "road": "Maneesikatu"
+  },
+  {
+    "uid": "e733d92b-8153-4b0a-b435-fd8eaab8bbcf",
+    "road": "Itämerenkatu",
+    "house_number": "21"
+  },
+  {
+    "uid": "8f5bf280-db42-4e04-9132-3e19c149589c",
+    "road": "Maneesikatu"
+  },
+  {
+    "uid": "cb554900-6c9f-4a9d-a75f-eff8b6cd5639",
+    "road": "Maneesikatu",
+    "house_number": "8"
+  },
+  {
+    "uid": "1a05a5f6-9920-4886-a60b-a28416d87234",
+    "road": "Selkämerenkatu"
+  },
+  {
+    "uid": "e123b196-bf82-4224-8ebb-f50f546a0bfb",
+    "road": "Itämerenkatu"
+  },
+  {
+    "uid": "ff740d85-7b51-4173-805b-0d4a2af958a5",
+    "road": "Maurinkatu",
+    "house_number": "4"
+  },
+  {
+    "uid": "87b036b0-c89b-4c4c-a0c4-04df1bfec3ba",
+    "road": "Liisankatu"
+  },
+  {
+    "uid": "0ce8624b-bba2-42c1-a851-4a2e0b0e775e",
+    "road": "Itämerenkatu"
+  },
+  {
+    "uid": "9a495a86-3970-4e54-8553-7de3cda76234",
+    "road": "Maurinkatu"
+  },
+  {
+    "uid": "e7863f1e-36d5-40bb-a6c5-73a9a063dc2e",
+    "road": "Itämerenkatu",
+    "house_number": "16"
+  },
+  {
+    "uid": "b8ae4428-e612-443f-bfa4-a6648e6977a5",
+    "road": "Itämerenkatu"
+  },
+  {
+    "uid": "a0c3a080-562a-4b1c-a698-f76eed8f4aa2",
+    "road": "Itämerentori"
+  },
+  {
+    "uid": "bb6cd8e9-b0f1-44df-8dec-ec416aebf049",
+    "road": "Maurinkatu"
+  },
+  {
+    "uid": "3394ae09-9c2b-453b-b14c-44c0f6663776",
+    "road": "Itämerentori"
+  },
+  {
+    "uid": "98cf59eb-7aaa-46fd-b26f-521f15e4e01b",
+    "road": "Maurinkatu",
+    "house_number": "14"
+  },
+  {
+    "uid": "b5ec8443-ba2b-4127-bb97-8b6cfba7f951",
+    "road": "Itämerenkatu",
+    "house_number": "5"
+  },
+  {
+    "uid": "93339971-f58b-4140-8fe4-0079a134b085",
+    "road": "Itämerenkatu",
+    "house_number": "9"
+  },
+  {
+    "uid": "96ea6d26-f750-4e4e-b109-1e657b1bb260",
+    "road": "Kristianinkatu"
+  },
+  {
+    "uid": "4a6a70df-42dd-4440-898e-6b55a2391c5f",
+    "road": "Maurinkatu",
+    "house_number": "14"
+  },
+  {
+    "uid": "7eb3958e-dad8-430c-bb86-74a789b13e23",
+    "road": "Kristianinkatu"
+  },
+  {
+    "uid": "89b441be-06f2-4e2f-9346-585b2cd353e4",
+    "road": "Itämerenkatu",
+    "house_number": "11-13 EF"
+  },
+  {
+    "uid": "6bf28799-a5ec-4e01-a302-9afad27f9a00",
+    "road": "Kristianinkatu",
+    "house_number": "3"
+  },
+  {
+    "uid": "e9af2f3c-1367-4a3a-b240-a3509881261e",
+    "road": "Itämerenkatu"
+  },
+  {
+    "uid": "df1223ac-7426-473d-b379-e9ca90900887",
+    "road": "Kristianinkatu",
+    "house_number": "7"
+  },
+  {
+    "uid": "8067208f-84e5-48cb-a5ff-560713c92154",
+    "road": "Kristianinkatu",
+    "house_number": "11-13"
+  },
+  {
+    "uid": "363ff2ac-d768-4a20-9784-c6df5b9489b8",
+    "road": "Kristianinkatu"
+  },
+  {
+    "uid": "95890905-2f92-4047-9751-1d9015761671",
+    "road": "Itämerenkatu"
+  },
+  {
+    "uid": "a000434a-be01-44c5-b4bc-5115a81e7983",
+    "road": "Pohjoisranta"
+  },
+  {
+    "uid": "2c9e2458-773e-48ea-b190-ba8176391893",
+    "road": "Selkämerenkatu",
+    "house_number": "4"
+  },
+  {
+    "uid": "bcd051c8-d5e7-43b3-97e3-8761835e5da6",
+    "road": "Pohjoisranta",
+    "house_number": "20"
+  },
+  {
+    "uid": "62f7f8a9-f166-4897-a6a5-076cb067ec00",
+    "road": "Selkämerenkatu"
+  },
+  {
+    "uid": "57af116d-3882-4b60-927f-5b6b784b1be0",
+    "road": "Ruoholahdentori",
+    "house_number": "6"
+  },
+  {
+    "uid": "7f5c0dd4-7c4a-4da3-9118-97d277528d21",
+    "road": "Pohjoisranta",
+    "house_number": "28"
+  },
+  {
+    "uid": "e455a0a0-97f8-4cf7-89bc-a72f51ba9935",
+    "road": "Selkämerenkatu",
+    "house_number": "6"
+  },
+  {
+    "uid": "6fb86efb-1652-4918-b792-9a927c405422",
+    "road": "Kirjatyöntekijänkatu"
+  },
+  {
+    "uid": "1a9d3b62-c6a3-41fa-9a59-c0c3ae0c23d3",
+    "road": "Kirjatyöntekijänkatu",
+    "house_number": "6"
+  },
+  {
+    "uid": "b6d4d093-ebf2-4d2f-b24a-8aed9e4c82c4",
+    "road": "Santakatu",
+    "house_number": "9"
+  },
+  {
+    "uid": "8a14dab8-4881-459d-91d2-099725a0ec73",
+    "road": "Santakatu",
+    "house_number": "12"
+  },
+  {
+    "uid": "6eb82d5f-1525-4f34-85d6-c27746469cef",
+    "road": "Santakatu",
+    "house_number": "9"
+  },
+  {
+    "uid": "8872376c-61b5-4994-b41f-849398e7c557",
+    "road": "Kirjatyöntekijänkatu",
+    "house_number": "8"
+  },
+  {
+    "uid": "a41de6e0-e99b-4ad7-8af0-5c0158187f53",
+    "road": "Kirjatyöntekijänkatu"
+  },
+  {
+    "uid": "32763ac7-4f5e-47e7-a392-3b3864f26425",
+    "road": "Santakatu",
+    "house_number": "9"
+  },
+  {
+    "uid": "652bda77-4504-4fed-9c26-7f8a3432c4d2",
+    "road": "Kirjatyöntekijänkatu"
+  },
+  {
+    "uid": "a28d5e5d-ca2f-42ca-81d6-0a8bf1a553b4",
+    "road": "Oikokatu"
+  },
+  {
+    "uid": "0c1a4653-fa7f-46c5-80e2-6553ad6da816",
+    "road": "Santakatu"
+  },
+  {
+    "uid": "bada1d94-8aa8-4b99-9e3a-8f7ff1ace54e",
+    "road": "Pohjoisesplanadi",
+    "house_number": "7B"
+  },
+  {
+    "uid": "fa534693-ed03-4d7c-ade5-33439c9e4ebe",
+    "road": "Santakatu",
+    "house_number": "6"
+  },
+  {
+    "uid": "9cc18297-842a-4138-9105-6c91eeb4321b",
+    "road": "Hakaniemen silta"
+  },
+  {
+    "uid": "af28914f-48c2-4fe7-9501-ec8048a4e6e9",
+    "road": "Satamakatu"
+  },
+  {
+    "uid": "73d885e1-afe8-4959-9e66-ca4a75249d01",
+    "road": "Santakatu",
+    "house_number": "6"
+  },
+  {
+    "uid": "b8fb03f5-c33b-4f58-a585-8c6757314302",
+    "road": "Pohjoisranta"
+  },
+  {
+    "uid": "d64bbd43-0039-4800-ab26-eab714e0749a",
+    "road": "Santakatu",
+    "house_number": "6"
+  },
+  {
+    "uid": "f0438595-981c-4def-bc34-6c7ea8b1c2e0",
+    "road": "Pohjoisranta"
+  },
+  {
+    "uid": "57f42a52-f9ed-4d47-a258-4de79bc65313",
+    "road": "Helenankatu"
+  },
+  {
+    "uid": "79a1a046-af30-4a46-a359-baf04262df9b",
+    "road": "Salmisaarenkatu",
+    "house_number": "1"
+  },
+  {
+    "uid": "70d7db20-b5a1-4bef-b6f7-76a2838a6675",
+    "road": "Helenankatu"
+  },
+  {
+    "uid": "a4c996c1-2629-4ed8-ac31-0687394c8803",
+    "road": "Pohjoisesplanadi",
+    "house_number": "5"
+  },
+  {
+    "uid": "1709d012-3a94-4070-a032-d18f4d84aa8a",
+    "road": "Lapinlahdentie"
+  },
+  {
+    "uid": "05d578ff-9f8d-445c-bee5-b76d08611861",
+    "road": "Pohjoisesplanadi",
+    "house_number": "11-13"
+  },
+  {
+    "uid": "cc1b4cab-3e20-4ac2-85a4-4e9ac0e49a16",
+    "road": "Lapinlahdentie"
+  },
+  {
+    "uid": "2e01ecbd-25f0-49b0-b2fb-6922dd0b20f3",
+    "road": "Lapinlahdentie"
+  },
+  {
+    "uid": "b1c27c67-1ac8-425f-b522-a07d048c9d01",
+    "road": "Lapinlahdentie",
+    "house_number": "2"
+  },
+  {
+    "uid": "405b7761-5bea-4b0e-8717-a35f13d7f781",
+    "road": "Aleksanterinkatu",
+    "house_number": "4"
+  },
+  {
+    "uid": "3aa30556-94dc-49e0-807d-4fd7ee1d8a98"
+  },
+  {
+    "uid": "c70369d4-032d-41a9-965c-a746909b62bf",
+    "road": "Siltavuorenranta"
+  },
+  {
+    "uid": "2ae8ada3-15fc-4c1d-91da-ed93c0c2d46f",
+    "road": "Siltavuorenranta"
+  },
+  {
+    "uid": "359c66cd-70e5-413e-a741-ebc23b0fa661",
+    "road": "Siltavuorenranta"
+  },
+  {
+    "uid": "4a4319a2-1bdc-4465-90ff-d64b84b67f01",
+    "road": "Siltavuorenranta"
+  },
+  {
+    "uid": "bf79ca73-b1e2-4e12-b4b7-7056732a61ee",
+    "road": "Siltavuorenranta"
+  },
+  {
+    "uid": "7f61e112-0bc8-4b48-87d3-cfedf8cca533",
+    "road": "Länsisatamankatu",
+    "house_number": "17"
+  },
+  {
+    "uid": "61f468b0-b91e-4f88-989a-06d659f3f33b",
+    "road": "Länsisatamankatu"
+  },
+  {
+    "uid": "2a7c51db-a0f7-4a59-8fc3-041f4af7e7bc",
+    "road": "Länsisatamankatu",
+    "house_number": "16"
+  },
+  {
+    "uid": "4546a7df-e714-451d-a370-03633a98196d",
+    "road": "Saukonpaadenranta",
+    "house_number": "2"
+  },
+  {
+    "uid": "de3979d7-0dbe-4d05-8c92-5b6904427695",
+    "road": "Siltavuorenranta",
+    "house_number": "16"
+  },
+  {
+    "uid": "d1176413-bdcc-44bd-942d-272147111f07",
+    "road": "Saukonpaadenranta",
+    "house_number": "2"
+  },
+  {
+    "uid": "f85b9c3f-8eb8-4561-a004-b9c56dea1439",
+    "road": "Saukonpaadenranta",
+    "house_number": "2"
+  },
+  {
+    "uid": "85d2c27e-7af1-44e0-89cf-a133ece3b8f4",
+    "road": "Siltavuorenpenger"
+  },
+  {
+    "uid": "2443cb15-84d5-420c-a0db-3085ae0e6c80",
+    "road": "Selkämerenkatu"
+  },
+  {
+    "uid": "a3f7f33c-33a2-476a-8cc8-3962acd6a3bf",
+    "road": "Messipojankuja"
+  },
+  {
+    "uid": "74a45351-2643-4ddb-b891-26830e1daf8e",
+    "road": "Siltavuorenpenger"
+  },
+  {
+    "uid": "015184d2-398c-4c47-9949-ddcef8c56838",
+    "road": "Siltavuorenpenger",
+    "house_number": "7"
+  },
+  {
+    "uid": "d8ba9d0e-9dbc-41b2-9ec1-d9479f32aa31",
+    "road": "Laivapojanaukio",
+    "house_number": "2"
+  },
+  {
+    "uid": "220a8120-1986-4f60-ac08-05edbe168edc",
+    "road": "Siltavuorenpenger",
+    "house_number": "7"
+  },
+  {
+    "uid": "a092ec37-0358-44de-ad15-f822b00098fe",
+    "road": "Messitytönkatu",
+    "house_number": "11"
+  },
+  {
+    "uid": "ecbfe4ea-1c94-41b2-a978-03acfb1a7e03",
+    "road": "Messitytönkatu",
+    "house_number": "5"
+  },
+  {
+    "uid": "35f2c615-d1f2-4444-9bdd-22d0d1765605",
+    "road": "Messitytönkatu",
+    "house_number": "5"
+  },
+  {
+    "uid": "c6c2b09f-86d2-4b86-8436-93d136e07f94",
+    "road": "Selkämerenkatu",
+    "house_number": "11"
+  },
+  {
+    "uid": "3c5d2395-15cc-406b-b4a2-d66af29c518e",
+    "road": "Selkämerenkatu",
+    "house_number": "7"
+  },
+  {
+    "uid": "98437a44-3f90-4d44-8a84-edbdb27e0e06",
+    "road": "Snellmaninkatu",
+    "house_number": "18"
+  },
+  {
+    "uid": "2047591a-2798-4b8a-80a1-4d1d0d5243e8",
+    "road": "Selkämerenkatu",
+    "house_number": "10"
+  },
+  {
+    "uid": "3543f226-fe4b-4a36-8ebf-3a93c94233fa",
+    "road": "Siltavuorenpenger",
+    "house_number": "5"
+  },
+  {
+    "uid": "1a0b1439-7bf5-4444-808a-ac3d945dd33c",
+    "road": "Selkämerenkatu",
+    "house_number": "11"
+  },
+  {
+    "uid": "1cde8039-c9bd-4c07-89fc-af3df4553d75",
+    "road": "Selkämerenkatu",
+    "house_number": "13"
+  },
+  {
+    "uid": "c153c620-2933-4040-97bf-c5e03fb858bf",
+    "road": "Siltavuorenpenger"
+  },
+  {
+    "uid": "2d005247-8779-4294-8ef8-449b1a654fee",
+    "road": "Snellmaninkatu",
+    "house_number": "18"
+  },
+  {
+    "uid": "004f81c4-b3d8-4114-92e4-dd8a810bc73a",
+    "road": "Selkämerenkatu",
+    "house_number": "12"
+  },
+  {
+    "uid": "13db92f1-e47f-4698-ab6f-efe7faf5e065",
+    "road": "Selkämerenkatu",
+    "house_number": "12"
+  },
+  {
+    "uid": "19620bf7-df73-4bbb-bcb5-5506472ced1a",
+    "road": "Oikokatu"
+  },
+  {
+    "uid": "19d18a05-26a5-4338-8a7a-9c4646a80ba9",
+    "road": "Heino Kasken katu",
+    "house_number": "2"
+  },
+  {
+    "uid": "89f1536b-43c7-48d2-a5a1-e7537cd0655f",
+    "road": "Länsisatamankatu",
+    "house_number": "23"
+  },
+  {
+    "uid": "1d2c1702-79f2-4316-8572-20ec30317cda",
+    "road": "Oikokatu",
+    "house_number": "8"
+  },
+  {
+    "uid": "d32adb2a-1480-4624-9b7d-597b65b37edd",
+    "road": "Länsisatamankatu"
+  },
+  {
+    "uid": "af2698c8-d1f4-481a-9f23-89c055d111cb",
+    "road": "Kulmakatu",
+    "house_number": "3"
+  },
+  {
+    "uid": "4b996254-c78e-41bb-9303-791e1842bca5",
+    "road": "Kulmakatu"
+  },
+  {
+    "uid": "c1a7f438-7bd2-4268-a860-31672b24ce91",
+    "road": "Kulmakatu",
+    "house_number": "4a"
+  },
+  {
+    "uid": "5f23f1e3-ebbc-4929-be82-8885ed0b9153",
+    "road": "Tyynenmerenkatu"
+  },
+  {
+    "uid": "407cadc5-8332-4635-b90d-ee1ea46dbd0b",
+    "road": "Kulmakatu",
+    "house_number": "5"
+  },
+  {
+    "uid": "05b68e4f-c3de-4099-817e-8eb11b6b8d46",
+    "road": "Tyynenmerenkatu"
+  },
+  {
+    "uid": "83f06dac-fcd0-422e-94e7-d57b5654b588",
+    "road": "Liisankatu",
+    "house_number": "13"
+  },
+  {
+    "uid": "315840f0-2072-4870-a214-4c332fc95e91",
+    "road": "Puistokatu"
+  },
+  {
+    "uid": "d5b2dffb-4125-4369-b215-a43702fbd787",
+    "road": "Tyynenmerenkatu"
+  },
+  {
+    "uid": "61376f40-e227-409d-83d8-5a061a8b2746",
+    "road": "Tyynenmerenkatu",
+    "house_number": "9"
+  },
+  {
+    "uid": "e85fcef4-942c-4e2b-90e4-0caf7a841fb5",
+    "road": "Liisankatu"
+  },
+  {
+    "uid": "fbdd55d6-556c-4a90-b531-a68f20edb349",
+    "road": "Tyynenmerentori"
+  },
+  {
+    "uid": "51663f79-4091-42f4-84ce-6f638d341081",
+    "road": "Liisankatu"
+  },
+  {
+    "uid": "d4f8be8d-5f5f-4c56-a618-063c145b9c7a",
+    "road": "Rionkatu",
+    "house_number": "3"
+  },
+  {
+    "uid": "b65eab72-d556-48b8-863b-43aab92771d0"
+  },
+  {
+    "uid": "ede683d7-dca5-4362-90f5-be2bbd91367f",
+    "road": "Tyynenmerenkatu",
+    "house_number": "11"
+  },
+  {
+    "uid": "d4aad022-cc28-4f90-b168-d42cdc9d8df8",
+    "road": "Snellmaninkatu",
+    "house_number": "18"
+  },
+  {
+    "uid": "6e9a3c3f-2aa1-4a22-96aa-957b59083767",
+    "road": "Liisankatu"
+  },
+  {
+    "uid": "5dfe3e79-32af-46b6-9e78-b98a329f196c",
+    "road": "Tyynenmerenkatu",
+    "house_number": "5"
+  },
+  {
+    "uid": "e9b6e20f-17a4-45c2-895d-fbc905e3edaf",
+    "road": "Suezinkatu",
+    "house_number": "1"
+  },
+  {
+    "uid": "7e4f278c-49e9-4299-af13-a391104c73a1",
+    "road": "Liisankatu"
+  },
+  {
+    "uid": "1a7f6988-84f4-40bb-af39-3c26ad6ece7a",
+    "road": "Suezinkatu",
+    "house_number": "4"
+  },
+  {
+    "uid": "3ecc31fc-4731-46a1-80bf-fe8bdcf85b4d",
+    "road": "Tyynenmerenkatu",
+    "house_number": "3"
+  },
+  {
+    "uid": "7688864a-eaa5-4298-bc68-0b1bb891d468",
+    "road": "Liisankatu",
+    "house_number": "13"
+  },
+  {
+    "uid": "27ef0a39-b1b7-4782-9d2b-5edb008cfc6f",
+    "road": "Tyynenmerenkatu",
+    "house_number": "5"
+  },
+  {
+    "uid": "643db27b-0679-465e-a02a-e593a28c4771",
+    "road": "Liisankatu",
+    "house_number": "19"
+  },
+  {
+    "uid": "30c32500-f5a1-4e27-88eb-b060d5dbb387",
+    "road": "Kap Hornin katu",
+    "house_number": "3"
+  },
+  {
+    "uid": "f672da17-615d-452a-aaf3-b4085f6c3f3f",
+    "road": "Liisankatu",
+    "house_number": "19"
+  },
+  {
+    "uid": "775a4b1c-4298-4ebf-8881-83f7d2f6c38d",
+    "road": "Liisankatu"
+  },
+  {
+    "uid": "3afdb8fb-680b-47b7-b7c1-d20b80a1562e",
+    "road": "Liisankatu",
+    "house_number": "9"
+  },
+  {
+    "uid": "53af54d7-4f4d-4cab-8eac-dcb846290f9d",
+    "road": "Liisankatu",
+    "house_number": "8"
+  },
+  {
+    "uid": "d4426aa5-01c0-4431-a57f-15870f98b4e9",
+    "road": "Liisankatu"
+  },
+  {
+    "uid": "f38fb8c1-7627-4303-ba23-d84aa159c718",
+    "road": "Välimerenkatu",
+    "house_number": "5 B"
+  },
+  {
+    "uid": "2876f272-d298-456d-b1c8-fe2c6adacaa1",
+    "road": "Välimerenkatu",
+    "house_number": "4"
+  },
+  {
+    "uid": "46c5698d-cc06-43c6-97c5-4adb77a7ff6d",
+    "road": "Välimerenkatu",
+    "house_number": "9"
+  },
+  {
+    "uid": "140df04d-34be-4a9e-a7c2-a2813798d0f1",
+    "road": "Munkkisaarenkatu",
+    "house_number": "3"
+  },
+  {
+    "uid": "585624c5-422b-41b6-be8a-e1aab665c92e",
+    "road": "Liisankatu",
+    "house_number": "7"
+  },
+  {
+    "uid": "f337a98a-903a-482c-89f9-8a045d048178",
+    "road": "Liisankatu"
+  },
+  {
+    "uid": "c75a5c56-2bb3-464f-b029-b5ba5aae19db",
+    "road": "Hylkeenpyytäjänkatu",
+    "house_number": "5"
+  },
+  {
+    "uid": "d668eeac-656b-4a40-8bde-699787433fde",
+    "road": "Liisankatu",
+    "house_number": "7"
+  },
+  {
+    "uid": "3968731e-6de4-4aa0-b604-849ebd3df49f",
+    "road": "Hernesaarenkatu"
+  },
+  {
+    "uid": "6dec65c0-7102-486a-9427-32bd6c86017b",
+    "road": "Kruununhaankatu"
+  },
+  {
+    "uid": "64c57221-fa4a-44eb-80f8-4fd9ba6c10a5",
+    "road": "Snellmaninkatu",
+    "house_number": "14"
+  },
+  {
+    "uid": "87ed56e5-0c2b-418c-8330-56aad81b6d8d",
+    "road": "Vironkatu"
+  },
+  {
+    "uid": "4ddb75ad-0494-48c8-bc7b-39da5bcf57c5",
+    "road": "Vironkatu",
+    "house_number": "5"
+  },
+  {
+    "uid": "9b7a7e01-f9dd-4b89-b3c9-7b7624e5affc",
+    "road": "Hernesaarenkatu",
+    "house_number": "5"
+  },
+  {
+    "uid": "f69a176e-268d-4619-9be1-9a4c67668688",
+    "road": "Vironkatu"
+  },
+  {
+    "uid": "1f0d4a60-3912-4dbf-bd3b-e00d74cfaed2",
+    "road": "Vironkatu",
+    "house_number": "10"
+  },
+  {
+    "uid": "d191899a-73d2-4d87-9ab0-68f897363b9a",
+    "road": "Vironkatu"
+  },
+  {
+    "uid": "3e26e3b3-e3a0-4fc1-8318-fe4657623934",
+    "road": "Eiranranta"
+  },
+  {
+    "uid": "c810d5fc-204a-46e5-b9dd-dfe547754605",
+    "road": "Vironkatu",
+    "house_number": "2"
+  },
+  {
+    "uid": "06f309e9-fd1e-4b8b-affd-6a3fa2f513c7",
+    "road": "Eiranranta",
+    "house_number": "3"
+  },
+  {
+    "uid": "96bd56e5-5691-4953-85d7-6ad8ed652a76",
+    "road": "Vironkatu",
+    "house_number": "2"
+  },
+  {
+    "uid": "660b164c-15e1-4a07-8016-df907e3d744a",
+    "road": "Vironkatu",
+    "house_number": "1"
+  },
+  {
+    "uid": "f0c4f59d-7cea-467d-a28e-fb7037ef06aa",
+    "road": "Laivakatu"
+  },
+  {
+    "uid": "0a6dcfd1-533a-4e02-81bf-c78bc8dc868a",
+    "road": "Snellmaninkatu",
+    "house_number": "13"
+  },
+  {
+    "uid": "c6b94210-749a-4bf6-bb59-f2fabcfd7d8e",
+    "road": "Laivakatu"
+  },
+  {
+    "uid": "8daeebf4-071c-4e1a-a8d0-3badf62d6da0",
+    "road": "Henry Fordin katu"
+  },
+  {
+    "uid": "7e99bdf3-1cf2-4434-83ab-39b81aff6a13",
+    "road": "Henry Fordin katu"
+  },
+  {
+    "uid": "3749241a-86a9-4a89-8ff2-f7d92194265c",
+    "road": "Hernesaarenranta"
+  },
+  {
+    "uid": "73c819d8-4321-4086-bacf-6ec3f2b497ab",
+    "road": "Hernesaarenranta"
+  },
+  {
+    "uid": "1759b483-01b0-431b-b629-a53e6a94c399",
+    "road": "Rauhankatu"
+  },
+  {
+    "uid": "346b0052-feed-4485-9690-c45849fd69a7",
+    "road": "Rauhankatu"
+  },
+  {
+    "uid": "076d2706-a1f7-4707-81b7-5ac680361468",
+    "road": "Hernesaarenranta",
+    "house_number": "3"
+  },
+  {
+    "uid": "7d2120db-56f8-48f5-89e1-5c02e9d90a8e",
+    "road": "Hernematalankatu",
+    "house_number": "1"
+  },
+  {
+    "uid": "fe2b7e20-20e6-42cc-83aa-12f522ce3693",
+    "road": "Hernesaarenranta"
+  },
+  {
+    "uid": "8d6fc576-8033-4d8e-963f-151938fe1aa6",
+    "road": "Hernematalankatu",
+    "house_number": "6"
+  },
+  {
+    "uid": "12c70e43-0b7f-475b-b79e-34a8867abecd",
+    "road": "Rauhankatu"
+  },
+  {
+    "uid": "41e78b37-4d9f-4c92-b01d-565636fd43c8",
+    "road": "Rauhankatu"
+  },
+  {
+    "uid": "32215fd9-2b30-42d8-b20f-2d3d9af92b35",
+    "road": "Rauhankatu",
+    "house_number": "11"
+  },
+  {
+    "uid": "e348cf93-e9be-4f22-bc48-9f97aac5d9ca",
+    "road": "Rauhankatu"
+  },
+  {
+    "uid": "a4339fe6-b3bb-418b-b818-a827034baba0",
+    "road": "Rauhankatu"
+  },
+  {
+    "uid": "fc19fe65-2e0d-4152-89e6-386b0694a37d",
+    "road": "Rauhankatu",
+    "house_number": "9"
+  },
+  {
+    "uid": "3006bba1-05b1-4a39-a6b9-f918b22d9efd",
+    "road": "Rauhankatu"
+  },
+  {
+    "uid": "fe7ab585-ad2a-41f5-aadd-40d80b464f4a",
+    "road": "Rauhankatu",
+    "house_number": "2a"
+  },
+  {
+    "uid": "afe5f13d-4348-41a7-bfa8-aa72d7ae97af",
+    "road": "Rauhankatu",
+    "house_number": "3"
+  },
+  {
+    "uid": "e74a6f33-52c4-49c8-b6cb-e8ecec6e2ded",
+    "road": "Yrjö-Koskisen katu"
+  },
+  {
+    "uid": "37a1f7a4-16f3-4dcd-9685-0194c9953b31",
+    "road": "Yliopistonkatu"
+  },
+  {
+    "uid": "7cafb165-4914-4a43-9cf1-e6a97e63953c",
+    "road": "Yliopistonkatu"
+  },
+  {
+    "uid": "33949904-2f09-4854-a450-626236c9a54a",
+    "road": "Senaatintori"
+  },
+  {
+    "uid": "6773df00-ca3c-4aff-8ad4-b17cad931369",
+    "road": "Senaatintori"
+  },
+  {
+    "uid": "249f2cb4-ed9c-4c43-9248-d1595c4b3d29",
+    "road": "Senaatintori"
+  },
+  {
+    "uid": "1eb3ce17-721c-4626-a38d-16c0dfeb78be",
+    "road": "Aleksanterinkatu"
+  },
+  {
+    "uid": "5ca9feab-16e1-45d1-85a9-a336c5b2aa9d"
+  },
+  {
+    "uid": "827d3d07-27fe-4890-abc6-e2ffcc5e89a7"
+  },
+  {
+    "uid": "8a106a47-77db-4660-b9cb-88b04b7e6ed1",
+    "road": "Snellmaninkatu",
+    "house_number": "1A"
+  },
+  {
+    "uid": "8d41590c-be0e-429a-bf11-6a3538e10255",
+    "road": "Senaatintori"
+  },
+  {
+    "uid": "383c03d2-b699-4e78-b911-26de81c3dab9",
+    "road": "Snellmaninkatu",
+    "house_number": "1A"
+  },
+  {
+    "uid": "ce65399c-ac36-4e93-b484-06fe4df12bbf"
+  },
+  {
+    "uid": "0ca59d8a-e766-4963-b635-3f73b2622dac",
+    "road": "Snellmaninkatu",
+    "house_number": "4"
+  },
+  {
+    "uid": "9f7939fb-8310-4931-b717-c17f4b90531e",
+    "road": "Kirkkokatu"
+  },
+  {
+    "uid": "3b1ce838-f19e-4173-bdbf-a538febbb7ba",
+    "road": "Snellmaninaukio"
+  },
+  {
+    "uid": "b422156d-c13f-4c15-bb55-96f5fecc33cb",
+    "road": "Aleksanterinkatu",
+    "house_number": "10"
+  },
+  {
+    "uid": "cec3f079-b4de-408f-acaa-bd552877ebe1",
+    "road": "Aleksanterinkatu"
+  },
+  {
+    "uid": "e288c030-0f67-4b77-8bb0-fa3965d10d2e",
+    "road": "Hallituskatu"
+  },
+  {
+    "uid": "ba89db01-1fa5-47d8-8a01-db38f2f27284",
+    "road": "Hallituskatu",
+    "house_number": "3"
+  },
+  {
+    "uid": "5dba390d-a094-481c-a30c-be1fa7114297",
+    "road": "Hallituskatu"
+  },
+  {
+    "uid": "2bba2a52-0e26-42ea-8aa5-986446556cbe",
+    "road": "Hallituskatu",
+    "house_number": "1"
+  },
+  {
+    "uid": "1fca742b-b6cb-409a-9664-dc96a13291c7",
+    "road": "Hallituskatu"
+  },
+  {
+    "uid": "74e85913-6c8d-4e5f-9336-42c8e9c91645",
+    "road": "Ritarikatu"
+  },
+  {
+    "uid": "22cf595c-7735-4f03-ba36-eb27d91de547",
+    "road": "Ritarikatu",
+    "house_number": "5"
+  },
+  {
+    "uid": "d0b918ae-1b46-49dd-a7a2-32f04e609070",
+    "road": "Kirkkokatu",
+    "house_number": "16"
+  },
+  {
+    "uid": "2619499f-3e63-4fc9-a7a5-e7e10faed2e6",
+    "road": "Ruoholahdenranta",
+    "house_number": "1"
+  },
+  {
+    "uid": "44281e7a-7d54-4fb3-8206-b9b2d3331ee8",
+    "road": "Kirkkokatu"
+  },
+  {
+    "uid": "6af32990-aeb9-47bd-a2d8-45c65f8a05d1",
+    "road": "Ruoholahdenranta",
+    "house_number": "3"
+  },
+  {
+    "uid": "37d3d360-70d3-4280-a4ba-33d86b598340",
+    "road": "Ruoholahdenranta"
+  },
+  {
+    "uid": "311f2372-84b6-4dbe-a826-54eb9d4e2c01",
+    "road": "Kirkkokatu"
+  },
+  {
+    "uid": "58d8bd83-edd0-467a-aec7-821fea1d0e37",
+    "road": "Kirkkokatu"
+  },
+  {
+    "uid": "a8b361da-f9fa-431a-bd88-b4e390d8475b",
+    "road": "Ruoholahdenranta",
+    "house_number": "7a"
+  },
+  {
+    "uid": "0d5c3b02-8eb4-4e72-81ab-f1ecb04daba1",
+    "road": "Kirkkokatu"
+  },
+  {
+    "uid": "d5f471f5-93a8-4146-9e7b-7ccffb3304a3",
+    "road": "Ruoholahdenranta",
+    "house_number": "7b"
+  },
+  {
+    "uid": "bf532176-9a47-4f80-933b-6aa7c110777c",
+    "road": "Ruoholahdenkatu",
+    "house_number": "26"
+  },
+  {
+    "uid": "ad89e493-d6a6-461e-ba2e-86fb8894a0e7",
+    "road": "Ruoholahdenkatu",
+    "house_number": "26"
+  },
+  {
+    "uid": "34b31e4a-286d-4fdd-b21d-de8f12022b9f",
+    "road": "Lönnrotinkatu",
+    "house_number": "45"
+  },
+  {
+    "uid": "2196e3a0-7e60-4d06-9258-3ac2fe646dc1",
+    "road": "Lönnrotinkatu"
+  },
+  {
+    "uid": "4512a0b7-b9d6-4daa-9089-bfde183aedee",
+    "road": "Lönnrotinkatu",
+    "house_number": "39"
+  },
+  {
+    "uid": "8519044c-b99f-4b61-9a6f-965ad5357b59",
+    "road": "Kirkkokatu",
+    "house_number": "2"
+  },
+  {
+    "uid": "e5dba03f-9674-44fa-9426-9b0194be297e",
+    "road": "Kirkkokatu",
+    "house_number": "1"
+  },
+  {
+    "uid": "7290652a-5074-4f21-8bba-3d5988414901",
+    "road": "Lönnrotinkatu",
+    "house_number": "43b"
+  },
+  {
+    "uid": "9d54cd9e-b53d-46d0-bbea-6531c19247fb",
+    "road": "Kirkkokatu",
+    "house_number": "2"
+  },
+  {
+    "uid": "eb9a46cd-55f5-4afa-a8a4-cdae5b67d367",
+    "road": "Kirkkokatu",
+    "house_number": "2"
+  },
+  {
+    "uid": "4d880c39-cd12-456d-8207-39e70b7fc933",
+    "road": "Lönnrotinkatu",
+    "house_number": "34"
+  },
+  {
+    "uid": "b1033287-cce3-45d3-8b7e-187ffa90baaa",
+    "road": "Lönnrotinkatu",
+    "house_number": "27"
+  },
+  {
+    "uid": "001fbefb-a8b6-478f-87da-1d0adae7000e",
+    "road": "Lönnrotinkatu",
+    "house_number": "29"
+  },
+  {
+    "uid": "3157cc66-f752-4d07-ade2-60f37eb34dcb",
+    "road": "Eteläesplanadi",
+    "house_number": "18"
+  },
+  {
+    "uid": "2e2d8cd0-7c2e-4f99-9728-c87e392f6534",
+    "road": "Lönnrotinkatu",
+    "house_number": "17"
+  },
+  {
+    "uid": "6971266a-69b5-4105-9514-9ebcdbd52cff",
+    "road": "Albertinkatu"
+  },
+  {
+    "uid": "f0821c27-e754-481f-b77a-da6959e18285",
+    "road": "Lönnrotinkatu"
+  },
+  {
+    "uid": "5a1a302d-af3c-44ac-aff9-5a3d23f4bdb0",
+    "road": "Lönnrotinkatu",
+    "house_number": "26"
+  },
+  {
+    "uid": "0abda7ea-6f57-42d3-95f3-d1f91d8c16b0",
+    "road": "Lönnrotinkatu",
+    "house_number": "9"
+  },
+  {
+    "uid": "5e2f2ed1-80b5-442f-bf80-8cd15da562f9",
+    "road": "Eteläesplanadi",
+    "house_number": "16"
+  },
+  {
+    "uid": "1085fe94-cbfc-4a73-a633-d9900438fdb4",
+    "road": "Eteläesplanadi",
+    "house_number": "16"
+  },
+  {
+    "uid": "9a5a603c-a960-439f-8d72-d5570e69baa4",
+    "road": "Eteläesplanadi",
+    "house_number": "12"
+  },
+  {
+    "uid": "dddf78d5-2c1e-4f30-887a-a33084a8f972",
+    "road": "Eteläesplanadi",
+    "house_number": "12"
+  },
+  {
+    "uid": "0a73d70c-4160-4b21-8555-1048905d867f",
+    "road": "Eteläesplanadi",
+    "house_number": "10"
+  },
+  {
+    "uid": "f407c16d-ca20-4022-9703-ee7711607b93",
+    "road": "Eteläesplanadi",
+    "house_number": "8"
+  },
+  {
+    "uid": "26b41f50-a842-442e-b572-629c281343e1",
+    "road": "Lönnrotinkatu",
+    "house_number": "15"
+  },
+  {
+    "uid": "bfd740c2-55b2-4f1e-99c1-3a91478e4760",
+    "road": "Lönnrotinkatu"
+  },
+  {
+    "uid": "18270f22-dc22-43bf-bf20-a4c06f245324",
+    "road": "Erottaja"
+  },
+  {
+    "uid": "542e70bf-6d06-4eee-a8f9-a042acb7356f",
+    "road": "Lönnrotinkatu",
+    "house_number": "6"
+  },
+  {
+    "uid": "54a7daf8-2a2f-488b-9b35-61ede25e4750",
+    "road": "Lönnrotinkatu"
+  },
+  {
+    "uid": "46325739-89b9-4cfd-adad-cc4a78377bbe",
+    "road": "Lönnrotinkatu",
+    "house_number": "7"
+  },
+  {
+    "uid": "d55d06d3-f01d-41ad-ae2a-734d05abb836",
+    "road": "Lönnrotinkatu"
+  },
+  {
+    "uid": "ca951b04-1b0e-45e1-a8aa-9d1a951b22a9",
+    "road": "Lönnrotinkatu"
+  },
+  {
+    "uid": "4fb012a1-fea5-4060-80b6-4a651dfc588a",
+    "road": "Lönnrotin puistikko",
+    "house_number": "1"
+  },
+  {
+    "uid": "ab49af0b-8a5e-4556-9a6f-72ab290ce024",
+    "road": "Lönnrotin puistikko"
+  },
+  {
+    "uid": "b83768ad-c5a3-4515-81d8-380473185e8d",
+    "road": "Pohjoisesplanadi"
+  },
+  {
+    "uid": "3939420e-8712-495b-ac4c-7b1757497702",
+    "road": "Eteläesplanadi"
+  },
+  {
+    "uid": "f929e9df-3d11-404a-9c66-76c938a98faf",
+    "road": "Pohjoisesplanadi"
+  },
+  {
+    "uid": "9b9f9bb4-29a0-41b7-8eac-10f97d999cb4",
+    "road": "Pohjoisesplanadi",
+    "house_number": "37"
+  },
+  {
+    "uid": "79404fb0-0030-4077-9886-fec9c06af355",
+    "road": "Pohjoisesplanadi"
+  },
+  {
+    "uid": "23c4f2cb-5d4c-4551-948a-7903a3ff5261",
+    "road": "Pohjoisesplanadi",
+    "house_number": "29"
+  },
+  {
+    "uid": "a894cac9-ba38-4bd5-a3e5-60cdc34600af",
+    "road": "Pohjoisesplanadi",
+    "house_number": "27"
+  },
+  {
+    "uid": "81a48bcd-85f1-47ab-a9c0-e5403b145702",
+    "road": "Pohjoisesplanadi",
+    "house_number": "25"
+  },
+  {
+    "uid": "fc8e0c81-d491-465f-9bb6-d6fab27caa7b",
+    "road": "Pohjoisesplanadi"
+  },
+  {
+    "uid": "899c8be1-3a79-4c33-a2e3-2a753e99af41",
+    "road": "Pohjoisesplanadi",
+    "house_number": "25"
+  },
+  {
+    "uid": "a26491e9-b983-4254-ad6d-d05266c104a0",
+    "road": "Yrjönkatu"
+  },
+  {
+    "uid": "6e639b60-9088-4394-91df-9d2290246c3c",
+    "road": "Pohjoisesplanadi",
+    "house_number": "19"
+  },
+  {
+    "uid": "e2957872-4d87-4899-a053-1320b8513425",
+    "road": "Pohjoisesplanadi",
+    "house_number": "21"
+  },
+  {
+    "uid": "0dd83e0c-ad2b-456f-be04-9da5f0924581",
+    "road": "Pohjoisesplanadi",
+    "house_number": "23"
+  },
+  {
+    "uid": "ffbdfec4-84db-4d35-b302-b1e5c1b3a889",
+    "road": "Yrjönkatu",
+    "house_number": "15"
+  },
+  {
+    "uid": "346947ce-2994-454a-94b9-3f4b32dc2fa6",
+    "road": "Yrjönkatu"
+  },
+  {
+    "uid": "c4faadd2-0d41-41c7-9e40-4935040d00ef",
+    "road": "Yrjönkatu",
+    "house_number": "26"
+  },
+  {
+    "uid": "e3dc4378-3196-4183-836e-49aaf5fae45e",
+    "road": "Fabianinkatu",
+    "house_number": "29"
+  },
+  {
+    "uid": "e45014a5-a02a-47f5-b5e3-2909c4370d1b",
+    "road": "Kalevankatu",
+    "house_number": "11"
+  },
+  {
+    "uid": "348bdea6-a8da-4706-a009-15de056d30af",
+    "road": "Yliopistonkatu"
+  },
+  {
+    "uid": "c4660d1b-1e05-4754-9b60-b5ffd9fe8d54",
+    "road": "Yliopistonkatu"
+  },
+  {
+    "uid": "230897d7-6327-48ee-a654-550563b7c0f2",
+    "road": "Kalevankatu",
+    "house_number": "13"
+  },
+  {
+    "uid": "099e0ead-eef0-41fb-8b4b-7b7ffa1d0c77",
+    "road": "Malminkatu",
+    "house_number": "3"
+  },
+  {
+    "uid": "0307c101-93ce-49f3-81af-640bf37772d4",
+    "road": "Yliopistonkatu"
+  },
+  {
+    "uid": "ee7b406f-c381-4894-a457-1fc80954afd9",
+    "road": "Kalevankatu"
+  },
+  {
+    "uid": "2cb6cf05-ed88-453a-b150-d5499574c7ec",
+    "road": "Yliopistonkatu"
+  },
+  {
+    "uid": "831426eb-6e42-40a8-afa2-9ec94189e6e7",
+    "road": "Yliopistonkatu"
+  },
+  {
+    "uid": "f2b6a61b-7081-45e1-a703-bda5bf489d6d",
+    "road": "Kalevankatu"
+  },
+  {
+    "uid": "c718ef39-f266-44f7-88d6-0a39424fc302",
+    "road": "Yliopistonkatu"
+  },
+  {
+    "uid": "fe881a68-2189-42e4-a97f-0add27c5a0bf",
+    "road": "Yliopistonkatu"
+  },
+  {
+    "uid": "2f3edeb5-104f-4f55-a9b2-f71771779866",
+    "road": "Yliopistonkatu"
+  },
+  {
+    "uid": "b56710ea-eb17-4e22-8b64-05d9636966fc",
+    "road": "Yliopistonkatu"
+  },
+  {
+    "uid": "5a750024-f267-45c6-9bc5-5f45922b0a89",
+    "road": "Kalevankatu",
+    "house_number": "14"
+  },
+  {
+    "uid": "26b0d70f-bf4a-4783-87ba-da6b87ffaab8",
+    "road": "Eteläinen Rautatiekatu",
+    "house_number": "6"
+  },
+  {
+    "uid": "91c62fc7-2896-4bde-a95b-173583f82866",
+    "road": "Yliopistonkatu"
+  },
+  {
+    "uid": "8311baec-7b06-4b46-8c5e-83e55432d0cf",
+    "road": "Kalevankatu"
+  },
+  {
+    "uid": "ef8dd42d-a01b-4c74-805d-dc55c8554ff4",
+    "road": "Yliopistonkatu"
+  },
+  {
+    "uid": "3c0ec092-b643-4038-b10e-8e1f0c93241f",
+    "road": "Kalevankatu",
+    "house_number": "21"
+  },
+  {
+    "uid": "a37730f6-f6f0-421d-9b58-1d85c417da4d",
+    "road": "Yliopistonkatu"
+  },
+  {
+    "uid": "e041b96c-9d7c-44c9-8738-1ddef53d377e",
+    "road": "Kalevankatu",
+    "house_number": "21"
+  },
+  {
+    "uid": "a81aed60-5d0a-4643-ae96-803fd866a54c",
+    "road": "Yliopistonkatu"
+  },
+  {
+    "uid": "f3d2527f-ba85-4006-83d5-abf45babbc15",
+    "road": "Fredrikinkatu",
+    "house_number": "45"
+  },
+  {
+    "uid": "38396151-6552-4cac-a991-4de3032e123a",
+    "road": "Yliopistonkatu"
+  },
+  {
+    "uid": "4b66d4c1-eb3e-45c4-a317-e4ef92a27ef2",
+    "road": "Kalevankatu",
+    "house_number": "20"
+  },
+  {
+    "uid": "86e7a1ee-b6d9-4781-8d1d-241e286f7905",
+    "road": "Yliopistonkatu"
+  },
+  {
+    "uid": "abfe55d8-b21d-4177-9342-8e3d1b425f2d",
+    "road": "Kalevankatu",
+    "house_number": "25"
+  },
+  {
+    "uid": "cf59dc82-5522-48ae-a4fd-12892d70a548",
+    "road": "Kalevankatu",
+    "house_number": "31"
+  },
+  {
+    "uid": "af81f62b-e1e7-4334-910e-f6d8fbe24a27",
+    "road": "Kalevankatu",
+    "house_number": "31"
+  },
+  {
+    "uid": "8e29c366-3795-45ad-aee8-850255278016",
+    "road": "Kalevankatu",
+    "house_number": "34"
+  },
+  {
+    "uid": "03783895-4e78-4ff0-9348-750039db4089",
+    "road": "Kalevankatu",
+    "house_number": "32"
+  },
+  {
+    "uid": "377bbb0c-9690-49bd-bb48-07fdf3dc9861",
+    "road": "Kalevankatu",
+    "house_number": "28"
+  },
+  {
+    "uid": "773f5cbf-1977-44e1-88a7-69aa9d2117d7",
+    "road": "Kalevankatu",
+    "house_number": "25"
+  },
+  {
+    "uid": "a5a6539f-8654-4722-ba53-85c5c020e86d",
+    "road": "Kalevankatu"
+  },
+  {
+    "uid": "9c9f0745-d06e-40b8-a48e-86b034a1ad6f",
+    "road": "Mikonkatu"
+  },
+  {
+    "uid": "70e68fa3-490e-49f0-8a4f-ffe4fcc0e11f",
+    "road": "Mikonkatu"
+  },
+  {
+    "uid": "4e2b13c3-62c1-40e4-a1ec-7429b69e41e6",
+    "road": "Kalevankatu"
+  },
+  {
+    "uid": "db1899e9-7699-4a93-8dcd-20ba05b363d5",
+    "road": "Asema-aukio"
+  },
+  {
+    "uid": "919d985f-d61d-4b9c-b0e1-1ff87e55747c",
+    "road": "Asema-aukio"
+  },
+  {
+    "uid": "1a6f4c7a-ecfa-4cfd-bf7f-f6b81918e6af",
+    "road": "Kompassitaso"
+  },
+  {
+    "uid": "f62163eb-bc61-4873-a861-5bf12f9b1c46"
+  },
+  {
+    "uid": "1380c9ec-307b-4b47-aae9-7104c70b0b7a",
+    "road": "Kalevankatu",
+    "house_number": "46"
+  },
+  {
+    "uid": "5eeb3e38-df12-435c-b8dd-a08808080883",
+    "road": "Kalevankatu",
+    "house_number": "46"
+  },
+  {
+    "uid": "dc96af97-6a48-4ff3-a6ca-5c3b4577c87e",
+    "road": "Asema-aukio"
+  },
+  {
+    "uid": "ba302acc-a723-46ad-b363-5c3f36999885",
+    "road": "Kalevankatu",
+    "house_number": "40"
+  },
+  {
+    "uid": "731cc9c7-6110-45eb-b970-d55de94a86a1",
+    "road": "Kalevankatu",
+    "house_number": "38"
+  },
+  {
+    "uid": "561b6706-e53d-49d6-beef-fd87d76c6126",
+    "road": "Kalevankatu",
+    "house_number": "49"
+  },
+  {
+    "uid": "7108adf9-316e-466d-ab24-67300336aa59",
+    "road": "Kalevankatu",
+    "house_number": "53"
+  },
+  {
+    "uid": "549e9728-66b5-489c-b131-15e6d02515a3",
+    "road": "Kalevankatu",
+    "house_number": "51"
+  },
+  {
+    "uid": "c1160739-c50a-40b2-9444-b8f19b39ccfa",
+    "road": "Mikonkatu"
+  },
+  {
+    "uid": "79fc2cf1-d646-4797-8470-6803812786a9",
+    "road": "Mikonkatu",
+    "house_number": "17"
+  },
+  {
+    "uid": "37cfda4b-050c-4511-8d72-5234ebd2fc0e",
+    "road": "Bergbominkuja"
+  },
+  {
+    "uid": "8421bba4-857e-4551-b96f-032a27267cf3",
+    "road": "Bergbominkuja"
+  },
+  {
+    "uid": "ec3671a4-8ff4-4af7-9e9e-0ffa6c3cfa2e",
+    "road": "Itäinen Teatterikuja",
+    "house_number": "1"
+  },
+  {
+    "uid": "efa9b888-9187-49cc-8a1d-cd4f753d2a86",
+    "road": "Itäinen Teatterikuja"
+  },
+  {
+    "uid": "cef8e1f6-3813-4f05-9fda-1510104444ca",
+    "road": "Itäinen Teatterikuja"
+  },
+  {
+    "uid": "e558f748-d288-4b50-9376-8ef28c9fd4fe",
+    "road": "Vilhonkatu"
+  },
+  {
+    "uid": "3af28813-79a5-4262-b911-5f2442feefa4",
+    "road": "Mikonkatu",
+    "house_number": "20"
+  },
+  {
+    "uid": "bd512e19-978f-4577-a533-3849433ef7f1",
+    "road": "Vuorikatu",
+    "house_number": "19"
+  },
+  {
+    "uid": "8d1d9e85-afd8-47dc-93c1-eeed9df86ef2",
+    "road": "Vuorikatu"
+  },
+  {
+    "uid": "976ba6cb-9263-49ed-a0ef-5f57bc20b8dc",
+    "road": "Vuorikatu",
+    "house_number": "19"
+  },
+  {
+    "uid": "9a4e023d-44df-4a83-b6da-b54808290692",
+    "road": "Vuorikatu",
+    "house_number": "19"
+  },
+  {
+    "uid": "6baa3be0-8331-44dc-9452-68fb35be3afe",
+    "road": "Kaisaniemen puistokuja"
+  },
+  {
+    "uid": "2c78fdfe-d9b5-43c0-bcce-81c3fc5b169a",
+    "road": "Kaisaniemenranta"
+  },
+  {
+    "uid": "157f8aec-37ea-4fe4-9203-6ffb4c301247",
+    "road": "Kaisaniemenranta",
+    "house_number": "2"
+  },
+  {
+    "uid": "2dc264c8-8327-4783-89e3-c0b177f24ec0",
+    "road": "Kaisaniemenranta",
+    "house_number": "2"
+  },
+  {
+    "uid": "da200360-ac21-4bc3-a3f2-ee6d4e9b5e21",
+    "road": "Kalevankatu"
+  },
+  {
+    "uid": "ca8c200b-b0b2-4a24-a79f-111c2335dde2",
+    "road": "Eerikinkatu"
+  },
+  {
+    "uid": "2d0fc639-c42a-4462-8d8d-505b1970ae2b",
+    "road": "Eerikinkatu",
+    "house_number": "9"
+  },
+  {
+    "uid": "379665d7-ad9b-49c3-86b2-8da97fc219d7",
+    "road": "Kaisaniemenranta"
+  },
+  {
+    "uid": "06af82e4-bb14-4ad2-b606-8858976bdcd9",
+    "road": "Eerikinkatu",
+    "house_number": "18"
+  },
+  {
+    "uid": "097dd32e-614c-4159-a6b7-fec8c3e54df0",
+    "road": "Eerikinkatu",
+    "house_number": "22"
+  },
+  {
+    "uid": "9e9889d6-764c-4a40-a01c-2112c60da67e",
+    "road": "Eerikinkatu",
+    "house_number": "24"
+  },
+  {
+    "uid": "3a962309-8e8d-4741-b12d-871506dc29ba",
+    "road": "Kaisaniemenranta"
+  },
+  {
+    "uid": "6f6cb471-33a2-494a-934f-160ee549cc37",
+    "road": "Eerikinkatu",
+    "house_number": "44"
+  },
+  {
+    "uid": "1399007f-9988-4de5-9149-2e50735a477f",
+    "road": "Eerikinkatu",
+    "house_number": "28"
+  },
+  {
+    "uid": "8d47ab99-6c6c-4a7e-a20f-cb8ac2fa7a37",
+    "road": "Eerikinkatu",
+    "house_number": "21"
+  },
+  {
+    "uid": "5e1e136f-68b0-48a3-b820-4c8203f9ac87",
+    "road": "Mannerheimin aukio",
+    "house_number": "2"
+  },
+  {
+    "uid": "c17c7cc4-3f51-432a-9fa3-5cbc14641d94",
+    "road": "Eerikinkatu",
+    "house_number": "31"
+  },
+  {
+    "uid": "69948c49-c310-44f8-82f2-54f933dfc999",
+    "road": "Eerikinkatu"
+  },
+  {
+    "uid": "e446900f-c38f-444d-980d-9635840327fc",
+    "road": "Asema-aukio"
+  },
+  {
+    "uid": "bda128b9-2ac3-4fc3-bee9-bf2e5e6d0958",
+    "road": "Eerikinkatu",
+    "house_number": "34"
+  },
+  {
+    "uid": "1b5418f4-d6ec-4a73-af5c-ac1ab12c20d1",
+    "road": "Töölönlahdenkatu",
+    "house_number": "2"
+  },
+  {
+    "uid": "792f7d88-d3b1-4b55-ac48-20a4a7f79f8d",
+    "road": "Albertinkatu",
+    "house_number": "40-42"
+  },
+  {
+    "uid": "265b3a11-ec1b-4766-829e-a1e726ebdacc",
+    "road": "Töölönlahdenkatu",
+    "house_number": "3"
+  },
+  {
+    "uid": "c1f1c729-c54f-4080-a0cf-6a3bdb2b60bb",
+    "road": "Töölönlahdenkatu",
+    "house_number": "3"
+  },
+  {
+    "uid": "1fce34ae-ccf3-4abc-9d2a-15a288af5798",
+    "road": "Karamzininranta",
+    "house_number": "2"
+  },
+  {
+    "uid": "286f91c4-77e1-440e-8a5c-b36ab899ffb4",
+    "road": "Kauppatori"
+  },
+  {
+    "uid": "5a1379d4-12a2-4477-bce6-ecba368f32a4",
+    "road": "Eerikinkatu",
+    "house_number": "33"
+  },
+  {
+    "uid": "50a18bb5-60f3-452d-af0a-af8d57a7a354",
+    "road": "Eerikinkatu"
+  },
+  {
+    "uid": "4abf1791-72cf-46b1-a260-077388b32d4a",
+    "road": "Eerikinkatu",
+    "house_number": "44"
+  },
+  {
+    "uid": "a1089191-552c-4350-bfa0-7cbbdf0c7d89"
+  },
+  {
+    "uid": "e5ec4cb2-349d-401c-8ba9-96e67ee04dcf",
+    "road": "Eerikinkatu",
+    "house_number": "48"
+  },
+  {
+    "uid": "0049d5c7-d9d7-4790-a30e-2a53cd8b8810"
+  },
+  {
+    "uid": "59bd8831-36c7-4ad5-86dc-d5b04ef1f868"
+  },
+  {
+    "uid": "d2071443-548c-408b-8db3-75459c4de5bf"
+  },
+  {
+    "uid": "917dab18-11c4-4f74-b4de-6a23188630a3",
+    "road": "Eerikinkatu"
+  },
+  {
+    "uid": "84ac1662-9dbd-46dd-967c-140237a7a706",
+    "road": "Eteläranta"
+  },
+  {
+    "uid": "f969f812-9436-4796-8e56-72b7574df799",
+    "road": "Eerikinkatu",
+    "house_number": "48"
+  },
+  {
+    "uid": "eb004f39-1384-4288-8a95-483549a78645",
+    "road": "Eteläranta",
+    "house_number": "6"
+  },
+  {
+    "uid": "8e30aa16-3cc6-4c27-b65c-afaad7d54078",
+    "road": "Eteläranta",
+    "house_number": "4"
+  },
+  {
+    "uid": "2035f699-4140-4643-88d5-d614afb5f1c5",
+    "road": "Köydenpunojankatu",
+    "house_number": "13"
+  },
+  {
+    "uid": "e0da7380-41b8-44f6-a6f8-aea4791bb361",
+    "road": "Eteläranta",
+    "house_number": "4"
+  },
+  {
+    "uid": "5f6ccdef-b29c-4afa-9e94-aad95557a9eb",
+    "road": "Köydenpunojankatu",
+    "house_number": "8b"
+  },
+  {
+    "uid": "6bb78f12-eb89-46a7-9812-7216c4342856",
+    "road": "Köydenpunojankatu",
+    "house_number": "8b"
+  },
+  {
+    "uid": "381bee5a-32a8-4408-b68b-b06d827e7a06",
+    "road": "Köydenpunojankatu",
+    "house_number": "8a"
+  },
+  {
+    "uid": "35bf26e6-964a-4b19-8b23-b513e89b7339",
+    "road": "Bernhardinkatu"
+  },
+  {
+    "uid": "359fabd8-1b13-4675-b576-fe4e4f18e539",
+    "road": "Bernhardinkatu",
+    "house_number": "4"
+  },
+  {
+    "uid": "65120364-5e41-4bb6-8d8b-85f2f9371c00",
+    "road": "Köydenpunojankatu",
+    "house_number": "7"
+  },
+  {
+    "uid": "1b9a6e52-37fd-4c90-ae9f-afbb598df496",
+    "road": "Köydenpunojankatu",
+    "house_number": "4 A"
+  },
+  {
+    "uid": "2f839fdf-13d1-4af7-8a7d-517247891961",
+    "road": "Unioninkatu",
+    "house_number": "17"
+  },
+  {
+    "uid": "701ab81b-c956-4626-815d-26f70eaba09b",
+    "road": "Unioninkatu",
+    "house_number": "19"
+  },
+  {
+    "uid": "f9295bc2-73c3-44b8-b0aa-fa10691b85d1",
+    "road": "Köydenpunojankatu",
+    "house_number": "4 A"
+  },
+  {
+    "uid": "1008eb79-6b66-4ad4-91d8-54eb5a5f2dde",
+    "road": "Unioninkatu",
+    "house_number": "15"
+  },
+  {
+    "uid": "58bb7365-606e-46e6-8aa7-36bc239a7ed6",
+    "road": "Hietalahdenranta"
+  },
+  {
+    "uid": "dc2f3a03-12b8-4b58-a1a1-3049d19b2e6e",
+    "road": "Unioninkatu"
+  },
+  {
+    "uid": "e26b5da0-b762-43b1-91e0-b3fe8359833f",
+    "road": "Unioninkatu"
+  },
+  {
+    "uid": "c8f2478f-fc72-46bb-8afb-f90733c11166",
+    "road": "Unioninkatu",
+    "house_number": "11"
+  },
+  {
+    "uid": "b4055d5d-1c40-4c69-8fdd-4cc79af18815",
+    "road": "Hietalahdentori"
+  },
+  {
+    "uid": "6420743a-5b6e-4ed0-8647-a36b30edff59",
+    "road": "Unioninkatu",
+    "house_number": "12"
+  },
+  {
+    "uid": "d40788e1-c906-4235-a6aa-028e0eef5f58",
+    "road": "Hietalahdenkatu",
+    "house_number": "18"
+  },
+  {
+    "uid": "3ab2b556-88cd-4de7-85ce-617615f1bbe2",
+    "road": "Hietalahdenkatu",
+    "house_number": "5"
+  },
+  {
+    "uid": "0888e37f-ecf8-464c-a858-473214e6e15d",
+    "road": "Unioninkatu",
+    "house_number": "2"
+  },
+  {
+    "uid": "5ac8705a-cfb4-4c4a-92b1-1d08177ac994",
+    "road": "Hietalahdenkatu"
+  },
+  {
+    "uid": "f3893d3d-a6ec-4659-9d28-dd5317a7ff72",
+    "road": "Unioninkatu"
+  },
+  {
+    "uid": "d5279a69-abc8-42f1-a036-5a0bcb2fc14b",
+    "road": "Unioninkatu"
+  },
+  {
+    "uid": "88a8cc75-a334-4968-bcf9-56d97163540f",
+    "road": "Hietalahdenkatu",
+    "house_number": "3"
+  },
+  {
+    "uid": "2cf67230-b3ec-4ed5-9321-16256006ca42",
+    "road": "Unioninkatu"
+  },
+  {
+    "uid": "fde5c3a1-b8cc-46fd-81be-c42af581169a",
+    "road": "Hietalahdenkatu",
+    "house_number": "10"
+  },
+  {
+    "uid": "efed8c71-c6b8-4cf6-8f0f-93c31321c87e",
+    "road": "Pohjoinen Makasiinikatu",
+    "house_number": "1"
+  },
+  {
+    "uid": "6e044a68-73e1-46d7-876d-be6c1d573bca",
+    "road": "Hietalahdenkatu",
+    "house_number": "8"
+  },
+  {
+    "uid": "f393a06f-0019-4f7b-9bc9-a5243115c7a7",
+    "road": "Pohjoinen Makasiinikatu",
+    "house_number": "1"
+  },
+  {
+    "uid": "6766194b-548f-429d-a10d-edbfe6a0e6a0",
+    "road": "Hietalahdenkatu",
+    "house_number": "4"
+  },
+  {
+    "uid": "cbd2375d-7bd0-48b1-8c21-9c39ead49b37",
+    "road": "Abrahaminkatu"
+  },
+  {
+    "uid": "4dfbd69b-c5b6-4b20-b537-d7e24616fe2a",
+    "road": "Abrahaminkatu"
+  },
+  {
+    "uid": "209ed602-70bf-4bfa-86ea-69ada51ef66d",
+    "road": "Abrahaminkatu",
+    "house_number": "17"
+  },
+  {
+    "uid": "99876ed1-bedf-401c-b668-911d26ba5e08",
+    "road": "Eerikinkatu",
+    "house_number": "42"
+  },
+  {
+    "uid": "3440f4fd-e8ff-4da3-9d50-4863da582c31",
+    "road": "Abrahaminkatu"
+  },
+  {
+    "uid": "4a6a3ee9-e87e-4c14-aa20-ffbf1a27e404",
+    "road": "Bulevardi",
+    "house_number": "31"
+  },
+  {
+    "uid": "e34c0b0b-ae3b-4e0d-9905-bf1f8ab58092",
+    "road": "Albertinkatu"
+  },
+  {
+    "uid": "c0aafffd-8a99-4cef-be4c-169a2cbd14cd",
+    "road": "Albertinkatu"
+  },
+  {
+    "uid": "a4b10b89-6d2a-459c-b222-17c29fec192c",
+    "road": "Albertinkatu",
+    "house_number": "33"
+  },
+  {
+    "uid": "a244727e-b35b-4f33-a726-a952e9aac387",
+    "road": "Fabianinkatu",
+    "house_number": "10"
+  },
+  {
+    "uid": "367a8370-2d58-44bd-8631-15859c272f92",
+    "road": "Fabianinkatu",
+    "house_number": "8"
+  },
+  {
+    "uid": "7cddd264-95fa-4a2f-8ae5-2740951e179b",
+    "road": "Fabianinkatu",
+    "house_number": "19"
+  },
+  {
+    "uid": "0e1faf10-2078-4535-a366-2b88d7f42aad",
+    "road": "Fabianinkatu",
+    "house_number": "17"
+  },
+  {
+    "uid": "80cff28d-930e-4a98-937b-13e9c1143060",
+    "road": "Fabianinkatu",
+    "house_number": "13"
+  },
+  {
+    "uid": "3b2c5886-d764-460c-8dab-2c02a2716004",
+    "road": "Eteläinen Makasiinikatu",
+    "house_number": "8"
+  },
+  {
+    "uid": "242d321a-4064-4864-a58f-df2703b5dde5",
+    "road": "Fabianinkatu",
+    "house_number": "2"
+  },
+  {
+    "uid": "b8c621f1-9b49-4908-9e57-35443430b4e7",
+    "road": "Fabianinkatu"
+  },
+  {
+    "uid": "1bf1dcd1-181a-429d-bcde-560773230d81",
+    "road": "Albertinkatu",
+    "house_number": "36"
+  },
+  {
+    "uid": "b41f8f18-7915-420c-a892-b34a10b46489",
+    "road": "Lönnrotinkatu",
+    "house_number": "27"
+  },
+  {
+    "uid": "4831cfaa-82cc-40b0-977a-a8c86903e8a2",
+    "road": "Fabianinkatu"
+  },
+  {
+    "uid": "4cb665cc-2bf6-4125-ad7d-074a62d2d7b3",
+    "road": "Albertinkatu",
+    "house_number": "31"
+  },
+  {
+    "uid": "522a6cb6-aa9b-4077-a0b3-d4eb1c234d23",
+    "road": "Fabianinkatu",
+    "house_number": "9"
+  },
+  {
+    "uid": "3c7f3a9d-1cec-42f9-83af-2cabc938527e",
+    "road": "Fabianinkatu"
+  },
+  {
+    "uid": "bad61cb3-ae7c-4ce3-ac40-d27dcf03cc49",
+    "road": "Albertinkatu"
+  },
+  {
+    "uid": "37e8424e-5c1f-41e0-8a52-2317aabd8932",
+    "road": "Unioninkatu",
+    "house_number": "2"
+  },
+  {
+    "uid": "3e2fbc6b-21ab-4b16-a8cf-35f71e5ddc77",
+    "road": "Albertinkatu",
+    "house_number": "27"
+  },
+  {
+    "uid": "7ee25836-48c7-403b-ab9d-d58fd357703a",
+    "road": "Postikuja"
+  },
+  {
+    "uid": "4e976bad-db31-4168-bdc8-9f99c0c97c40",
+    "road": "Rikhardinkatu"
+  },
+  {
+    "uid": "470a9672-63b6-4144-b8cf-2eb67a862827",
+    "road": "Bernhardinkatu"
+  },
+  {
+    "uid": "9d3a6d98-b9b7-4121-9401-f1b2bf34e1cc",
+    "road": "Bernhardinkatu"
+  },
+  {
+    "uid": "679b0c37-d0b5-4496-b847-b55daf0265e5",
+    "road": "Albertinkatu",
+    "house_number": "30"
+  },
+  {
+    "uid": "7089414f-5d94-4f60-b59d-4a16a54781fb",
+    "road": "Albertinkatu",
+    "house_number": "21"
+  },
+  {
+    "uid": "a986b576-a22a-4c2a-9cfc-f2f5d986e30f",
+    "road": "Albertinkatu",
+    "house_number": "23"
+  },
+  {
+    "uid": "6ddd9d6d-8a6f-4d0e-9118-5365adf85e36",
+    "road": "Fredrikinkatu",
+    "house_number": "40"
+  },
+  {
+    "uid": "bd4bd2a5-a80d-4ee7-9778-ebd08161e113",
+    "road": "Eteläinen Makasiinikatu",
+    "house_number": "5"
+  },
+  {
+    "uid": "55549b81-d8c8-4201-9996-bf8cef994d38",
+    "road": "Eteläinen Makasiinikatu",
+    "house_number": "4"
+  },
+  {
+    "uid": "ad87e207-523c-4c6f-8529-461b362e1c90",
+    "road": "Pohjoinen Makasiinikatu"
+  },
+  {
+    "uid": "294df873-0fa0-43eb-bd1d-258f15bcd730",
+    "road": "Pohjoinen Makasiinikatu",
+    "house_number": "6"
+  },
+  {
+    "uid": "e46e82fa-a602-49af-bad4-145ce275f85c",
+    "road": "Pohjoinen Makasiinikatu"
+  },
+  {
+    "uid": "c15d82b7-daa6-473b-9ef5-80de292178c4",
+    "road": "Pohjoinen Makasiinikatu",
+    "house_number": "6"
+  },
+  {
+    "uid": "6d733c52-897b-472b-a5d4-26cd04dd80a4",
+    "road": "Eteläesplanadi",
+    "house_number": "14"
+  },
+  {
+    "uid": "7ff3380c-e832-49e2-8524-211b8756cde1",
+    "road": "Kasarmikatu",
+    "house_number": "44"
+  },
+  {
+    "uid": "588b068c-da30-41be-81de-73d6cd282b93",
+    "road": "Kasarmikatu",
+    "house_number": "23"
+  },
+  {
+    "uid": "779410d9-c980-4f40-9789-ef3e5a4ce060",
+    "road": "Kasarmikatu"
+  },
+  {
+    "uid": "a88812ce-68e5-4598-9985-537369a51437",
+    "road": "Kasarmikatu",
+    "house_number": "21"
+  },
+  {
+    "uid": "5bed7c82-8196-4800-8203-d5b9709d5a66",
+    "road": "Kasarmikatu",
+    "house_number": "40"
+  },
+  {
+    "uid": "21ac7c9b-216e-43ea-a479-720be1969587",
+    "road": "Kasarmikatu",
+    "house_number": "19"
+  },
+  {
+    "uid": "86a929c8-ac65-42a5-b89b-cd89eddcc8f4",
+    "road": "Kasarmikatu"
+  },
+  {
+    "uid": "af951fa5-8681-4fb8-ae39-db599e28b168",
+    "road": "Kasarmikatu",
+    "house_number": "30"
+  },
+  {
+    "uid": "c831234b-4d45-4de8-8cad-9ab69eed8cd1",
+    "road": "Kasarmikatu"
+  },
+  {
+    "uid": "c4973df8-6c97-4379-847a-9d19b6e6ff73",
+    "road": "Kaartinkuja"
+  },
+  {
+    "uid": "6ff04b46-a6d8-492b-ada9-6cdd6a1387dd",
+    "road": "Kasarmikatu",
+    "house_number": "24"
+  },
+  {
+    "uid": "ebe35cf6-bc09-47aa-a11d-7a845b35e1ec",
+    "road": "Kaartinkuja"
+  },
+  {
+    "uid": "b38c1785-889e-4ed8-8d81-d6bac7cc27a7",
+    "road": "Kaartinkuja"
+  },
+  {
+    "uid": "4fc484df-c53c-4377-bef3-0820eb581476",
+    "road": "Kaartinkuja"
+  },
+  {
+    "uid": "da08eea4-2951-45b8-ad13-0c8e10e79e5c",
+    "road": "Kasarmikatu",
+    "house_number": "15"
+  },
+  {
+    "uid": "25fcd492-b0d2-4afd-8d03-f6779f7017a8",
+    "road": "Kasarmikatu",
+    "house_number": "15"
+  },
+  {
+    "uid": "181ca4be-8595-48ad-9012-711ac276ad3e",
+    "road": "Kaartinkuja"
+  },
+  {
+    "uid": "e7510450-7a15-4d95-be22-36ba3e6031a0",
+    "road": "Kaartinkuja",
+    "house_number": "2a"
+  },
+  {
+    "uid": "8d18709d-69c3-41a5-914d-bea3b8f7dd1e",
+    "road": "Eteläinen Makasiinikatu",
+    "house_number": "8"
+  },
+  {
+    "uid": "effcca58-af38-4bbb-a0fc-ad5f1d62c2c0",
+    "road": "Eteläinen Makasiinikatu",
+    "house_number": "8"
+  },
+  {
+    "uid": "14cd38da-1b5c-465b-b09d-bbbcce4a2038",
+    "road": "Fredrikinkatu",
+    "house_number": "47"
+  },
+  {
+    "uid": "101e3619-273d-4ca9-8d6d-118d966044ea",
+    "road": "Kasarmitori"
+  },
+  {
+    "uid": "ec3e208e-ce67-41f4-82d7-3d0231ddca54",
+    "road": "Fredrikinkatu",
+    "house_number": "36"
+  },
+  {
+    "uid": "4f8b4cbd-b355-48a2-9909-2ce888540fc8",
+    "road": "Kasarmitori"
+  },
+  {
+    "uid": "c41830f2-76a5-4caa-bdcf-e0572247674e",
+    "road": "Fredrikinkatu",
+    "house_number": "38"
+  },
+  {
+    "uid": "d6468d25-1e50-4c6f-a4c0-3d255b2b0340",
+    "road": "Eteläinen Makasiinikatu"
+  },
+  {
+    "uid": "afc7564b-56f2-40e4-b471-4fff95341ee9",
+    "road": "Fredrikinkatu",
+    "house_number": "43"
+  },
+  {
+    "uid": "ae2a408f-109e-47c3-ad50-1f54e013c377",
+    "road": "Pohjoinen Makasiinikatu"
+  },
+  {
+    "uid": "4e341f4d-48fc-43aa-b06f-d6b652443f70",
+    "road": "Fredrikinkatu",
+    "house_number": "32"
+  },
+  {
+    "uid": "69908468-abd4-4537-8b87-c90cd738b326",
+    "road": "Kasarmitori"
+  },
+  {
+    "uid": "a62ed8ed-44f4-447d-861d-aa3d95c8a3e9",
+    "road": "Fredrikinkatu",
+    "house_number": "34"
+  },
+  {
+    "uid": "20e3e4ac-1b35-44ea-a5a6-6f571c72f0c8",
+    "road": "Pohjoinen Makasiinikatu"
+  },
+  {
+    "uid": "1459a75c-a406-40b7-b759-0588a6180d70",
+    "road": "Pohjoinen Makasiinikatu",
+    "house_number": "7"
+  },
+  {
+    "uid": "64f0006e-0dfa-4470-85e3-d29cf28a667c",
+    "road": "Pohjoinen Makasiinikatu",
+    "house_number": "9"
+  },
+  {
+    "uid": "c4ce33a3-cd6a-449e-acb4-4ef9d6c5d44e",
+    "road": "Fredrikinkatu",
+    "house_number": "43"
+  },
+  {
+    "uid": "5ea89990-6daa-45c0-b02d-199c8386288a",
+    "road": "Pohjoinen Makasiinikatu"
+  },
+  {
+    "uid": "5c664d27-4a96-4dc6-860b-46340959b951",
+    "road": "Korkeavuorenkatu"
+  },
+  {
+    "uid": "1e27fc11-2227-482a-a565-e56d4b30280d",
+    "road": "Fredrikinkatu",
+    "house_number": "39"
+  },
+  {
+    "uid": "2029160d-11e7-41e8-83ec-f5eed9ccda97",
+    "road": "Korkeavuorenkatu",
+    "house_number": "34"
+  },
+  {
+    "uid": "23bdf4d3-f057-4666-b683-c54575dcfa97",
+    "road": "Fredrikinkatu",
+    "house_number": "41"
+  },
+  {
+    "uid": "4cd408be-22e0-4a85-8194-287891065de0",
+    "road": "Korkeavuorenkatu",
+    "house_number": "41"
+  },
+  {
+    "uid": "55e4a512-90a1-40cb-b572-f920f82ea05f",
+    "road": "Fredrikinkatu",
+    "house_number": "30"
+  },
+  {
+    "uid": "1eb80f88-c5b5-4655-b2a1-7103da5b5326",
+    "road": "Annankatu",
+    "house_number": "27"
+  },
+  {
+    "uid": "bb308fd7-bf48-47c3-9bb7-68cbb3e20275",
+    "road": "Korkeavuorenkatu"
+  },
+  {
+    "uid": "18298883-9f10-4893-9d5b-eddbd572cb5d",
+    "road": "Annankatu",
+    "house_number": "31-33"
+  },
+  {
+    "uid": "cc330eaa-1a4f-4b97-8b96-2cf242a2777b",
+    "road": "Korkeavuorenkatu"
+  },
+  {
+    "uid": "591e320e-b2e8-4123-b9df-f365d6615f1b",
+    "road": "Annankatu",
+    "house_number": "31-33"
+  },
+  {
+    "uid": "c85a3578-026d-4615-a057-f8da829e4445",
+    "road": "Annankatu",
+    "house_number": "26"
+  },
+  {
+    "uid": "9c10eb0b-ef8b-4c88-8159-74dd2268bac1",
+    "road": "Pieni Roobertinkatu",
+    "house_number": "10"
+  },
+  {
+    "uid": "a24fd7c2-c698-4e89-860b-1a83521e368d",
+    "road": "Annankatu",
+    "house_number": "24"
+  },
+  {
+    "uid": "dadaec86-5606-47a4-9d66-d47c3becdd31",
+    "road": "Annankatu",
+    "house_number": "23"
+  },
+  {
+    "uid": "52cfc3df-b3fe-456a-aa5a-760a213414a8",
+    "road": "Korkeavuorenkatu",
+    "house_number": "27"
+  },
+  {
+    "uid": "cdb7a214-3314-4f56-896f-b449a44d79d7",
+    "road": "Annankatu",
+    "house_number": "25"
+  },
+  {
+    "uid": "9bb1dd91-1425-47f5-925c-277c049e8d4e",
+    "road": "Annankatu"
+  },
+  {
+    "uid": "c1635b09-61c3-4d5b-87b9-9a63c181f96d",
+    "road": "Korkeavuorenkatu"
+  },
+  {
+    "uid": "22756c68-707a-46e5-acf2-5ca1145141cb",
+    "road": "Annankatu",
+    "house_number": "20"
+  },
+  {
+    "uid": "3e44c6d9-9074-4234-9e33-e2d95f160c00",
+    "road": "Annankatu",
+    "house_number": "22"
+  },
+  {
+    "uid": "bebc1ede-56f2-447d-8be2-95cefa93d4d1",
+    "road": "Korkeavuorenkatu",
+    "house_number": "25"
+  },
+  {
+    "uid": "f5744f96-aae8-4898-bfc4-649e5be1151f",
+    "road": "Annankatu",
+    "house_number": "22"
+  },
+  {
+    "uid": "ab792286-2bab-4c57-847d-b0a904319649",
+    "road": "Annankatu",
+    "house_number": "20"
+  },
+  {
+    "uid": "7fcbad2b-0a48-472c-bfc8-ad9537c7aa65",
+    "road": "Annankatu"
+  },
+  {
+    "uid": "0ac708a1-6407-4200-95a8-a5df3409649a",
+    "road": "Merimiehenkatu"
+  },
+  {
+    "uid": "a47fb966-6c7c-41af-9e82-241845fa6344",
+    "road": "Annankatu"
+  },
+  {
+    "uid": "9d9d73cf-df53-445d-8b8a-a8bcb02ccf07",
+    "road": "Annankatu",
+    "house_number": "18"
+  },
+  {
+    "uid": "e525ed55-6171-4d05-880b-61f602620ee5",
+    "road": "Yrjönkatu",
+    "house_number": "1b"
+  },
+  {
+    "uid": "a307f6ef-8c32-49cf-bdaf-7455205a3b54",
+    "road": "Annankatu",
+    "house_number": "18"
+  },
+  {
+    "uid": "9f622fdc-4e3b-4570-8a74-2a50efb72dff",
+    "road": "Ratakatu",
+    "house_number": "1b"
+  },
+  {
+    "uid": "7c4c8254-0aae-4f39-8dd9-dd5e3f4b4c4b",
+    "road": "Annankatu",
+    "house_number": "16"
+  },
+  {
+    "uid": "85f38c3f-f779-4568-9b97-73c831371f17",
+    "road": "Ratakatu",
+    "house_number": "1a"
+  },
+  {
+    "uid": "22aed9a6-1101-4d8c-b65a-9444b047e544",
+    "road": "Ratakatu",
+    "house_number": "1a"
+  },
+  {
+    "uid": "50d009b1-53ca-45f5-8e69-a5d75b69ff47",
+    "road": "Ratakatu",
+    "house_number": "1a"
+  },
+  {
+    "uid": "823ca903-f950-4f15-80f6-b3ca19d1e01b",
+    "road": "Annankatu"
+  },
+  {
+    "uid": "1c690820-b718-495c-8988-293b83862f8f",
+    "road": "Ratakatu",
+    "house_number": "1b"
+  },
+  {
+    "uid": "c05dc6f8-3741-45b6-a9dd-e5cc5cb4c33b",
+    "road": "Pieni Roobertinkatu"
+  },
+  {
+    "uid": "fec1f863-cfc5-4c20-9bb6-837a50aaaf99",
+    "road": "Pieni Roobertinkatu",
+    "house_number": "16"
+  },
+  {
+    "uid": "6b8960bc-fc00-4f69-bb18-1489af83f02b",
+    "road": "Pieni Roobertinkatu",
+    "house_number": "12-14"
+  },
+  {
+    "uid": "41e4a9bb-d144-4066-99a9-bbe8e3c9577f",
+    "road": "Postikuja"
+  },
+  {
+    "uid": "58d203b5-cc00-4e9a-95f6-5b2a07a90eaa",
+    "road": "Annankatu"
+  },
+  {
+    "uid": "5c0abc02-c4f6-4ffc-a800-77d62071df63",
+    "road": "Pieni Roobertinkatu"
+  },
+  {
+    "uid": "44fab456-7810-40f3-964e-c8b145c83809",
+    "road": "Bulevardi",
+    "house_number": "16b"
+  },
+  {
+    "uid": "9defbcc0-a0f7-4280-9dcf-b24955dd8a17",
+    "road": "Bulevardi",
+    "house_number": "16b"
+  },
+  {
+    "uid": "ecbbc08d-557e-42a7-b069-637356f96607",
+    "road": "Annankatu",
+    "house_number": "12"
+  },
+  {
+    "uid": "00cfbb85-f82d-4832-bf0c-63432702db5f",
+    "road": "Pieni Roobertinkatu",
+    "house_number": "16"
+  },
+  {
+    "uid": "ab8cd1af-2fad-4b62-b55d-defc8b0c52a0",
+    "road": "Pieni Roobertinkatu",
+    "house_number": "13"
+  },
+  {
+    "uid": "6b1fac80-e0ab-48d6-88d4-f2f7dbee687c",
+    "road": "Fredrikinkatu",
+    "house_number": "35"
+  },
+  {
+    "uid": "e0666e1a-485b-4071-935e-48c6f7a0bb29",
+    "road": "Erottajankatu",
+    "house_number": "1"
+  },
+  {
+    "uid": "b13b021e-2201-4af9-a80c-4563643c91e0",
+    "road": "Erottajankatu",
+    "house_number": "5"
+  },
+  {
+    "uid": "41573410-b4f0-497c-b51e-9e8058d8ee40",
+    "road": "Erottajankatu",
+    "house_number": "7"
+  },
+  {
+    "uid": "ee19f9b3-3f6f-44dc-bd9a-029cfd4ccf49",
+    "road": "Ludviginkatu",
+    "house_number": "7"
+  },
+  {
+    "uid": "4221cb4a-c417-4ff3-8e48-1f05f0a2177b",
+    "road": "Ludviginkatu",
+    "house_number": "6-8"
+  },
+  {
+    "uid": "07e70e21-7265-46d4-851d-f11c5d8913ba",
+    "road": "Ludviginkatu",
+    "house_number": "3-5"
+  },
+  {
+    "uid": "0ffc387a-374b-4f51-8176-edbc974e5258",
+    "road": "Erottajankatu",
+    "house_number": "19"
+  },
+  {
+    "uid": "125f6052-f091-4397-b57b-8b3b59863d51",
+    "road": "Annankatu",
+    "house_number": "18"
+  },
+  {
+    "uid": "1710bc22-4588-4eb6-96d1-3c8f6e917aec",
+    "road": "Yrjönkatu"
+  },
+  {
+    "uid": "eecd627b-743f-4a92-b021-591438d867e6",
+    "road": "Yrjönkatu",
+    "house_number": "16"
+  },
+  {
+    "uid": "89921991-47e1-4be9-86a7-7c130fdc475c",
+    "road": "Yrjönkatu",
+    "house_number": "5"
+  },
+  {
+    "uid": "32c95242-07f5-4760-97e4-8cc5a5e57697",
+    "road": "Yrjönkatu"
+  },
+  {
+    "uid": "938bde97-f9c5-4c30-b3eb-eb0ee99d2a22",
+    "road": "Yrjönkatu",
+    "house_number": "9"
+  },
+  {
+    "uid": "7aacc35e-0e66-482c-a42f-66a882e2bfc3",
+    "road": "Yrjönkatu"
+  },
+  {
+    "uid": "fb70382d-7998-4d7d-95b2-adc11a7bffad",
+    "road": "Yrjönkatu"
+  },
+  {
+    "uid": "6360f61b-72f1-4932-9cc1-f4c8a7e17326",
+    "road": "Yrjönkatu"
+  },
+  {
+    "uid": "fe2ffec4-8233-4086-ab8e-a8203db28df6",
+    "road": "Yrjönkatu"
+  },
+  {
+    "uid": "51aa4005-dc81-4031-802d-0fd8e78292e2",
+    "road": "Ullanlinnankatu"
+  },
+  {
+    "uid": "3095abc0-795d-4a20-abd5-9231795b336b",
+    "road": "Korkeavuorenkatu",
+    "house_number": "23"
+  },
+  {
+    "uid": "1df7d6a1-955f-4051-ab98-b6fc976c81df",
+    "road": "Punanotkonkatu"
+  },
+  {
+    "uid": "57042c42-28c0-4bc4-a028-97af9c01e431",
+    "road": "Korkeavuorenkatu"
+  },
+  {
+    "uid": "299d0443-3e44-43d7-afcf-9f77c233b580",
+    "road": "Korkeavuorenkatu",
+    "house_number": "23"
+  },
+  {
+    "uid": "881a5688-a735-47c2-a3ce-cb2a23f447e4",
+    "road": "Punanotkonkatu",
+    "house_number": "2"
+  },
+  {
+    "uid": "0f91b67a-185e-4a2e-af69-a3b2a22bab98",
+    "road": "Punanotkonkatu",
+    "house_number": "4"
+  },
+  {
+    "uid": "190487ba-d54e-441d-abde-ebf9602644ae",
+    "road": "Punanotkonkatu",
+    "house_number": "4"
+  },
+  {
+    "uid": "af5618c1-d870-477d-a05a-b1cf19f430e5",
+    "road": "Merimiehenkatu",
+    "house_number": "7"
+  },
+  {
+    "uid": "d86be946-9125-47ab-9411-9badf5f5c05b",
+    "road": "Ratakatu"
+  },
+  {
+    "uid": "79b893bc-7eb4-43dd-8924-4e616601d4cf",
+    "road": "Laivurinrinne"
+  },
+  {
+    "uid": "ca0cc619-06f2-4d0d-8f2b-2330e2156432",
+    "road": "Laivurinrinne"
+  },
+  {
+    "uid": "6756042b-7e11-4176-8aca-28bc3680310d",
+    "road": "Laivurinrinne",
+    "house_number": "1"
+  },
+  {
+    "uid": "e7f6b130-3c0d-43d3-8f55-d9afcff44e39",
+    "road": "Johanneksenrinne",
+    "house_number": "1"
+  },
+  {
+    "uid": "ba701bae-e4ef-4035-a19c-ecdb8f294183",
+    "road": "Bulevardi",
+    "house_number": "1"
+  },
+  {
+    "uid": "8f8da282-ed3d-4747-a46d-83bff7bc649c",
+    "road": "Bulevardi",
+    "house_number": "3"
+  },
+  {
+    "uid": "d5360b7f-b589-48be-9812-b6f2c5133af2",
+    "road": "Bulevardi"
+  },
+  {
+    "uid": "2769ac7b-6b51-4c6a-bdbe-511a5531ecd9",
+    "road": "Bulevardi",
+    "house_number": "14"
+  },
+  {
+    "uid": "73e7661b-9597-47f3-9b41-3080db4834c8",
+    "road": "Bulevardi",
+    "house_number": "14"
+  },
+  {
+    "uid": "fc8df361-793e-4d37-8378-6130bb6bdb1b",
+    "road": "Bulevardi",
+    "house_number": "14"
+  },
+  {
+    "uid": "122caed3-6090-454c-bbe8-d06641805a66",
+    "road": "Bulevardi",
+    "house_number": "5"
+  },
+  {
+    "uid": "b98ca274-9f77-482c-9710-3784fd02c94b",
+    "road": "Bulevardi",
+    "house_number": "5"
+  },
+  {
+    "uid": "57a7a12c-249d-43bc-9437-53395a8feaae",
+    "road": "Bulevardi",
+    "house_number": "16"
+  },
+  {
+    "uid": "2339135a-6d62-461c-91dd-760d1d16160a"
+  },
+  {
+    "uid": "6ed6f824-b01b-48e8-bc5e-84d0883aa295",
+    "road": "Bulevardi",
+    "house_number": "11"
+  },
+  {
+    "uid": "f6dfae4e-c9be-448b-a07c-a15e061d1f8b",
+    "road": "Bulevardi",
+    "house_number": "22"
+  },
+  {
+    "uid": "4a50fe32-89ef-4c5f-b036-4bf77ae8513e",
+    "road": "Bulevardi"
+  },
+  {
+    "uid": "5e9a7b76-9a0d-4244-ab0e-398376ea1082",
+    "road": "Bulevardi"
+  },
+  {
+    "uid": "2e442605-8ae9-4e1f-b31f-287ad15275c5",
+    "road": "Bulevardi",
+    "house_number": "16"
+  },
+  {
+    "uid": "63200560-f777-4aac-b7cd-923b3f9923c5",
+    "road": "Johanneksenrinne",
+    "house_number": "2"
+  },
+  {
+    "uid": "184bb638-ea52-47be-b886-5756963ae050",
+    "road": "Bulevardi",
+    "house_number": "15"
+  },
+  {
+    "uid": "7bf1dc73-3dfb-4fd1-8ca3-94a642455045",
+    "road": "Bulevardi",
+    "house_number": "21"
+  },
+  {
+    "uid": "6b06853b-263c-484a-9747-5d7740d24e34",
+    "road": "Laivurinrinne",
+    "house_number": "2"
+  },
+  {
+    "uid": "b36146af-6fca-4ebb-a001-83c8bd9e45b4",
+    "road": "Bulevardi",
+    "house_number": "28"
+  },
+  {
+    "uid": "13d998ad-681e-4280-b6f3-5e60f5f7d00b",
+    "road": "Laivurinrinne",
+    "house_number": "1"
+  },
+  {
+    "uid": "680e5d64-caf3-4270-8141-ede98acce7cd",
+    "road": "Tarkk'ampujankatu"
+  },
+  {
+    "uid": "16640330-ea7d-4121-ad2d-6077a131ca9d",
+    "road": "Tarkk'ampujankatu"
+  },
+  {
+    "uid": "28b2858f-39db-4f6d-bb55-e29d359d7fbe",
+    "road": "Bulevardi",
+    "house_number": "26"
+  },
+  {
+    "uid": "f8d28e2e-f4d8-435d-852b-51a5bbe5d3a7",
+    "road": "Bulevardi",
+    "house_number": "34a"
+  },
+  {
+    "uid": "be37cda5-b661-4c19-8e74-4ff43ae4e7dd",
+    "road": "Kampintori"
+  },
+  {
+    "uid": "8e62dedc-0fde-4138-b89d-c80dee286dc7",
+    "road": "Kansakoulukatu",
+    "house_number": "1b"
+  },
+  {
+    "uid": "464bd467-d4a8-4eaf-ad0c-cf0230b99226",
+    "road": "Bulevardi",
+    "house_number": "36"
+  },
+  {
+    "uid": "5fccb05f-8044-4af1-a192-2b74dacbaa91",
+    "road": "Bulevardi",
+    "house_number": "29 A"
+  },
+  {
+    "uid": "04fb7d41-fe1d-4020-8d81-7d62322673aa",
+    "road": "Bulevardi",
+    "house_number": "31"
+  },
+  {
+    "uid": "415be1e4-7b48-41fe-b0cc-83124e474231",
+    "road": "Bulevardi"
+  },
+  {
+    "uid": "f616efe4-d34c-4123-b991-cf868fb758b6",
+    "road": "Bulevardi"
+  },
+  {
+    "uid": "b4a62c1d-95db-465e-94b7-1d4da687ccd3",
+    "road": "Tarkk'ampujankatu",
+    "house_number": "10"
+  },
+  {
+    "uid": "a22de308-ea40-4e6d-9bc6-04f150e16879",
+    "road": "Bulevardi"
+  },
+  {
+    "uid": "c6a58b3e-88b4-4645-a875-d84192156cca",
+    "road": "Korkeavuorenkatu",
+    "house_number": "8"
+  },
+  {
+    "uid": "902cfd62-0b63-4f90-9362-86ff45a6972e",
+    "road": "Korkeavuorenkatu",
+    "house_number": "13"
+  },
+  {
+    "uid": "1ec6e5ba-6a4f-4f32-a720-381361904706",
+    "road": "Johanneksenkuja"
+  },
+  {
+    "uid": "32ac48c9-e3ca-4704-a12c-d8af0b809f54",
+    "road": "Jääkärinkatu"
+  },
+  {
+    "uid": "0207ef3d-45ea-4934-a95e-a91d4bc20e83",
+    "road": "Lapinlahdenkatu",
+    "house_number": "3"
+  },
+  {
+    "uid": "fd728ce7-0dfe-4cc0-a723-e059ad49f4b2",
+    "road": "Hietalahdenranta",
+    "house_number": "17"
+  },
+  {
+    "uid": "5a6ea8e5-7568-4ab2-80e5-1575b3a16c31",
+    "road": "Korkeavuorenkatu",
+    "house_number": "19"
+  },
+  {
+    "uid": "e8c4cbab-9141-4f1a-a049-5d3c14a4f238",
+    "road": "Yrjönkatu"
+  },
+  {
+    "uid": "a7b46313-e2ae-4585-801e-1453915f9791",
+    "road": "Ruoholahdenkatu",
+    "house_number": "12"
+  },
+  {
+    "uid": "3bee4047-f682-4655-b420-7e31e2076948",
+    "road": "Ruoholahdenkatu",
+    "house_number": "10"
+  },
+  {
+    "uid": "06556209-45bf-482d-9a89-2b09474bc6fd",
+    "road": "Laivurinkatu",
+    "house_number": "41"
+  },
+  {
+    "uid": "68154d57-6196-4ea3-8f28-318525c9c296",
+    "road": "Jääkärinkatu"
+  },
+  {
+    "uid": "2e91ca2a-7fac-403f-8730-287da21a56bf",
+    "road": "Ruoholahdenkatu",
+    "house_number": "10"
+  },
+  {
+    "uid": "dab60334-dad9-487d-a855-cdcb0bc1872a",
+    "road": "Jääkärinkatu",
+    "house_number": "15b"
+  },
+  {
+    "uid": "6b195966-b568-423b-967f-e8437089b9eb",
+    "road": "Lapinlahdenkatu",
+    "house_number": "1"
+  },
+  {
+    "uid": "5f1cdd3f-757f-4447-b298-04fe686fcd2e",
+    "road": "Fredrikinkatu",
+    "house_number": "61"
+  },
+  {
+    "uid": "c1728dda-c654-428a-9bd2-d1568181802a",
+    "road": "Jääkärinkatu",
+    "house_number": "4"
+  },
+  {
+    "uid": "898ef7f8-d179-4279-93fa-fe41904c1ac7",
+    "road": "Malminrinne",
+    "house_number": "2-4"
+  },
+  {
+    "uid": "154d8bad-84f3-4893-9f28-1acdaee910ff",
+    "road": "Malminrinne",
+    "house_number": "2"
+  },
+  {
+    "uid": "1bc2a9da-2e25-47ae-9ffb-f000bfd87712",
+    "road": "Korkeavuorenkatu",
+    "house_number": "5"
+  },
+  {
+    "uid": "46ddb7d8-ca44-47cc-83b1-e7d3d3395acc",
+    "road": "Kampintori"
+  },
+  {
+    "uid": "148d9d72-d7de-41dd-b44d-945b70a1096a",
+    "road": "Kampintori"
+  },
+  {
+    "uid": "6439b203-4d5a-4ba9-80ef-824c8e1ea9d5",
+    "road": "Kampintori"
+  },
+  {
+    "uid": "384ebf2b-4431-46ea-97b7-3c355bc308e5",
+    "road": "Fredrikinkatu",
+    "house_number": "59"
+  },
+  {
+    "uid": "a20ff2df-696d-4777-ad8b-51dadc899b54",
+    "road": "Fredrikinkatu",
+    "house_number": "61"
+  },
+  {
+    "uid": "6e2b9cbe-2f2c-4cf6-975a-00a920d0b074",
+    "road": "Kansakoulukatu",
+    "house_number": "3"
+  },
+  {
+    "uid": "7a819089-547a-41ef-85ce-d8cf37c5e8cb",
+    "road": "Kansakoulukatu",
+    "house_number": "3"
+  },
+  {
+    "uid": "18e5e212-25eb-4eb0-96ec-02b38d7445ef",
+    "road": "Kansakoulukatu",
+    "house_number": "3"
+  },
+  {
+    "uid": "2f994005-6ccc-48d0-8eba-5383da01ec20",
+    "road": "Yrjönkatu",
+    "house_number": "32"
+  },
+  {
+    "uid": "11de84c1-f378-46b7-b514-0b721e7ae665",
+    "road": "Yrjönkatu",
+    "house_number": "32"
+  },
+  {
+    "uid": "5846c62b-f509-49d9-a373-ad8c5ecd6652",
+    "road": "Yrjönkatu",
+    "house_number": "36"
+  },
+  {
+    "uid": "8471d809-2b4b-4805-b15c-48c763e46815",
+    "road": "Arkadiankatu"
+  },
+  {
+    "uid": "5529d2e0-2e3f-43a8-82fd-d14880ea1e9d",
+    "road": "Korkeavuorenkatu",
+    "house_number": "6"
+  },
+  {
+    "uid": "89443f09-27a4-453f-8727-10bf18c4559e",
+    "road": "Korkeavuorenkatu"
+  },
+  {
+    "uid": "9c63e1ce-b523-4589-b02b-0ca735938155",
+    "road": "Tarkk'ampujankatu"
+  },
+  {
+    "uid": "6dcef26b-6b16-4911-b10f-f3f4daac68c9",
+    "road": "Punanotkonkatu",
+    "house_number": "2"
+  },
+  {
+    "uid": "1f592d5a-8994-437d-abd2-08893adecb7a",
+    "road": "Laivurinkatu",
+    "house_number": "37"
+  },
+  {
+    "uid": "011c2fe5-619a-40c3-bab7-51c47e9a097e",
+    "road": "Tähtitorninkatu",
+    "house_number": "2"
+  },
+  {
+    "uid": "8617bc18-0e92-4e17-ab64-44fadefcbc89",
+    "road": "Vuorimiehenkatu",
+    "house_number": "22"
+  },
+  {
+    "uid": "837d1b7f-e88d-4c2f-91f9-3070fbb8a36f",
+    "road": "Vuorimiehenkatu"
+  },
+  {
+    "uid": "283238de-ba38-41d3-9890-338b5d79d5b3",
+    "road": "Vuorimiehenkatu"
+  },
+  {
+    "uid": "a65755f8-d2b7-4240-9fe0-d9c893abe410",
+    "road": "Vuorimiehenkatu",
+    "house_number": "31"
+  },
+  {
+    "uid": "738f5d17-4ce3-4e41-b614-8a41d9a8ddeb",
+    "road": "Jääkärinkatu"
+  },
+  {
+    "uid": "b03f0312-9819-4a9e-ada4-801659092ba6",
+    "road": "Vuorimiehenkatu"
+  },
+  {
+    "uid": "4d4d0527-81b8-4da8-a0db-342d9cb119bb",
+    "road": "Vuorimiehenkatu",
+    "house_number": "23"
+  },
+  {
+    "uid": "b7b43c7e-83c5-4db5-b3b9-1cf693ed29d1",
+    "road": "Vuorimiehenkatu"
+  },
+  {
+    "uid": "331dca7e-7592-4263-911d-894f6e8b763a",
+    "road": "Kasarmikatu",
+    "house_number": "4"
+  },
+  {
+    "uid": "bbfe914d-3bf9-4cb5-8c33-bc3a31a82216",
+    "road": "Kasarmikatu",
+    "house_number": "11-13"
+  },
+  {
+    "uid": "441148c5-6f04-4c0c-85ba-85f831dad1ca",
+    "road": "Tarkk'ampujankatu"
+  },
+  {
+    "uid": "eadb122a-9455-45a4-956a-747647f63927",
+    "road": "Tähtitorninkatu",
+    "house_number": "8"
+  },
+  {
+    "uid": "68f04bb6-25fa-4172-bf28-e94011f6be6c",
+    "road": "Tähtitorninkatu",
+    "house_number": "14"
+  },
+  {
+    "uid": "18410c6f-05e5-43b2-b481-e9f6e4e598c3",
+    "road": "Laivurinkatu"
+  },
+  {
+    "uid": "65c38d74-9fcd-47c3-8400-89d9716dbc99",
+    "road": "Laivurinkatu",
+    "house_number": "33"
+  },
+  {
+    "uid": "18afde1e-b6f4-4501-8719-679ee5d6b4bc",
+    "road": "Tehtaankatu",
+    "house_number": "21"
+  },
+  {
+    "uid": "68228511-ee56-4375-be5b-275c7267acab",
+    "road": "Laivurinkatu",
+    "house_number": "29"
+  },
+  {
+    "uid": "44bdeac6-6006-468d-aa65-c77cd4567069",
+    "road": "Tehtaankatu",
+    "house_number": "19"
+  },
+  {
+    "uid": "1523467f-094c-4dd8-9d9f-7d425b20526c",
+    "road": "Tehtaankatu",
+    "house_number": "15-17"
+  },
+  {
+    "uid": "01f6e435-3c47-4e36-b2f0-af515cd70d87",
+    "road": "Tehtaankatu",
+    "house_number": "13"
+  },
+  {
+    "uid": "137e1590-154b-443d-af06-4c06f4dec93a",
+    "road": "Tehtaankatu",
+    "house_number": "15-17"
+  },
+  {
+    "uid": "79777661-9413-4470-b666-54939f5eb487",
+    "road": "Tehtaankatu",
+    "house_number": "15-17"
+  },
+  {
+    "uid": "c43eee9c-d30c-4785-b227-16ede6972712",
+    "road": "Kapteeninkatu",
+    "house_number": "11"
+  },
+  {
+    "uid": "28ac0611-efc1-4a65-b931-d8e0dd663c46",
+    "road": "Kapteeninkatu"
+  },
+  {
+    "uid": "74c019bf-c494-4ae7-a0c6-578cbdd0dff2",
+    "road": "Pietarinkatu",
+    "house_number": "26"
+  },
+  {
+    "uid": "630cdcc9-4d5b-46a4-930a-622f13b4a2a8",
+    "road": "Tehtaankatu",
+    "house_number": "22"
+  },
+  {
+    "uid": "2b430bcc-5e48-4a60-8ac1-8d2c88ca41c9",
+    "road": "Tehtaankatu",
+    "house_number": "14"
+  },
+  {
+    "uid": "ff7babc9-7038-420b-8281-0a70693120c4",
+    "road": "Tehtaankatu",
+    "house_number": "14"
+  },
+  {
+    "uid": "add59d41-75c9-4b8c-9765-58ff002cfa0f",
+    "road": "Tehtaankatu",
+    "house_number": "5"
+  },
+  {
+    "uid": "fa51f200-3692-4b4c-b4e4-2ac737d10359",
+    "road": "Tehtaankatu"
+  },
+  {
+    "uid": "5f1136aa-570f-474c-890d-aabcc11e882d",
+    "road": "Vuorimiehenkatu"
+  },
+  {
+    "uid": "46c620e7-d5a9-4466-ac63-01d86d69ebc0",
+    "road": "Runeberginkatu"
+  },
+  {
+    "uid": "7b74d330-8ab3-4665-b2a4-59a8ceccc785",
+    "road": "Laivurinkatu"
+  },
+  {
+    "uid": "9668b898-6da5-482d-a9dd-ebf09a34492b",
+    "road": "Runeberginkatu"
+  },
+  {
+    "uid": "4ce1af82-579b-4378-aa03-5f9db8aec144",
+    "road": "Laivurinkatu"
+  },
+  {
+    "uid": "dc00400f-be2b-4c07-a9fe-71a721fedaa1",
+    "road": "Laivurinkatu",
+    "house_number": "29"
+  },
+  {
+    "uid": "cd5f6bfc-08a9-418c-b290-3d4fc5d05ad3",
+    "road": "Runeberginkatu"
+  },
+  {
+    "uid": "c5b286d2-69b2-4c99-9ed8-1215e83c1a2e",
+    "road": "Laivurinkatu",
+    "house_number": "29"
+  },
+  {
+    "uid": "594ba663-3ca9-4d95-a8ee-80421935c79b",
+    "road": "Laivasillankatu"
+  },
+  {
+    "uid": "eea83f46-d03c-4872-a6f6-2d36e51c9e38",
+    "road": "Runeberginkatu",
+    "house_number": "2"
+  },
+  {
+    "uid": "7b480b34-8ab8-422f-b171-7f83ea8d51fd",
+    "road": "Pietarinkatu"
+  },
+  {
+    "uid": "eb5b433d-9cde-49cf-bf49-d8c3c5f95ec8",
+    "road": "Lapinlahdenkatu",
+    "house_number": "17"
+  },
+  {
+    "uid": "7a2b0c2c-b239-4b18-a671-9f848f68d3af",
+    "road": "Lapinlahdenkatu",
+    "house_number": "9"
+  },
+  {
+    "uid": "c879105b-ac60-4a5e-8485-7857e1707f47",
+    "road": "Lapinlahdenkatu",
+    "house_number": "15"
+  },
+  {
+    "uid": "52295159-bfc7-4417-a98c-92dce36a200e",
+    "road": "Malminkatu",
+    "house_number": "28"
+  },
+  {
+    "uid": "00deaede-67aa-43d0-a41a-e1f71b4ee197",
+    "road": "Huvilakatu",
+    "house_number": "16"
+  },
+  {
+    "uid": "bdc5e241-3295-47c8-a048-cda769d7f0bf",
+    "road": "Laivurinkatu",
+    "house_number": "29"
+  },
+  {
+    "uid": "4525049e-c3eb-459d-9bc1-d28b2a37bd76",
+    "road": "Pietarinkatu"
+  },
+  {
+    "uid": "54eda041-fef8-4fcc-9990-6f7036c4750f",
+    "road": "Malminkatu"
+  },
+  {
+    "uid": "57086655-dad2-471e-aa7b-856e5eef702a",
+    "road": "Pietarinkatu"
+  },
+  {
+    "uid": "3732330e-c0fd-4bb6-a6f7-cdb10267e588",
+    "road": "Kapteeninkatu",
+    "house_number": "14"
+  },
+  {
+    "uid": "7fe449c0-3e5a-4f12-b3f1-dfdf5e618c68",
+    "road": "Runeberginkatu",
+    "house_number": "2"
+  },
+  {
+    "uid": "7d1dd8f4-0dd9-4390-a338-78777d1bb59b",
+    "road": "Malminkatu",
+    "house_number": "3"
+  },
+  {
+    "uid": "1c08aabc-cf34-4afa-82e7-6b23c4b387ec",
+    "road": "Malminkatu",
+    "house_number": "3"
+  },
+  {
+    "uid": "c3b5472e-5584-4bc2-a8b9-3bb068907fc0",
+    "road": "Eteläinen Rautatiekatu",
+    "house_number": "18"
+  },
+  {
+    "uid": "6425f1ba-dee9-4940-803d-58665357d203",
+    "road": "Malminkatu",
+    "house_number": "36"
+  },
+  {
+    "uid": "d3b3b497-ea3e-4440-a89c-821795503585",
+    "road": "Kapteeninkatu",
+    "house_number": "16"
+  },
+  {
+    "uid": "975e4ade-bc9c-4f6b-a32d-5c6493af6298",
+    "road": "Kapteeninkatu"
+  },
+  {
+    "uid": "d820f801-9137-462c-850c-782b5b52d860",
+    "road": "Kapteeninkatu",
+    "house_number": "12"
+  },
+  {
+    "uid": "72bf3911-3e10-4d97-a2f4-b54244141284",
+    "road": "Kapteeninkatu",
+    "house_number": "7"
+  },
+  {
+    "uid": "fadcdc92-a9e4-4cb6-8a14-741dc94baaa9",
+    "road": "Kapteeninkatu"
+  },
+  {
+    "uid": "03723a23-ab4a-41e2-a6f0-31a2a7732a66",
+    "road": "Kapteeninkatu",
+    "house_number": "9"
+  },
+  {
+    "uid": "664de9cb-5819-4f4f-b113-de1eb1a920dc",
+    "road": "Pietarinkatu"
+  },
+  {
+    "uid": "a78d93f5-da4e-41fc-baf9-23b9cd9b0f97",
+    "road": "Pietarinkatu"
+  },
+  {
+    "uid": "853197b5-4f2e-4c1f-b721-5b123ab1c180",
+    "road": "Pietarinkatu",
+    "house_number": "12"
+  },
+  {
+    "uid": "62cc9640-4e47-4e44-9ca2-9babad10e4f5",
+    "road": "Pietarinkatu",
+    "house_number": "8"
+  },
+  {
+    "uid": "aea415b4-2024-4c76-87f8-ac1353061fcf",
+    "road": "Lapinlahdenkatu",
+    "house_number": "19"
+  },
+  {
+    "uid": "757793f2-58ec-4b8d-aaa5-09ec39ef3d6c",
+    "road": "Lastenkodinkuja"
+  },
+  {
+    "uid": "05831d52-e483-49e8-8bf5-26d24f8ce75c",
+    "road": "Neitsytpolku"
+  },
+  {
+    "uid": "b6db3301-7b58-49c7-ba9b-480f54927b8a",
+    "road": "Lapinlahdenkatu"
+  },
+  {
+    "uid": "0229262b-2d50-4869-a28e-852a90e23edd",
+    "road": "Neitsytpolku",
+    "house_number": "7"
+  },
+  {
+    "uid": "2492c93e-20de-4a5d-aa8a-43303f690fb6",
+    "road": "Lastenkodinkuja"
+  },
+  {
+    "uid": "192e0f82-fbb4-44ee-a1d9-f18e747df065",
+    "road": "Lapinlahdenkatu",
+    "house_number": "23"
+  },
+  {
+    "uid": "c1182dd8-a041-452f-9901-b89ca672aaa9",
+    "road": "Neitsytpolku",
+    "house_number": "9"
+  },
+  {
+    "uid": "988c004d-7d99-4ba6-b648-5e2c22193e13",
+    "road": "Neitsytpolku",
+    "house_number": "10"
+  },
+  {
+    "uid": "33627737-8719-4ee9-a5dc-f1e2f2a6221f",
+    "road": "Lastenkodinkatu",
+    "house_number": "9"
+  },
+  {
+    "uid": "609cfd01-d85f-4a98-b33e-bb9d8e474855",
+    "road": "Lastenkodinkuja"
+  },
+  {
+    "uid": "51797f1c-efd0-4ba2-a9bb-1321cd5a31a7",
+    "road": "Laivurinkatu"
+  },
+  {
+    "uid": "78399e78-61df-4f75-8eb2-47a0374e632c",
+    "road": "Lastenkodinkuja"
+  },
+  {
+    "uid": "7ed5b614-4fde-4f96-ad12-ed9c2bd5b5c8",
+    "road": "Laivurinkatu"
+  },
+  {
+    "uid": "02a1bc72-0c40-4f1f-986d-90fed76dec9e",
+    "road": "Laivurinkatu",
+    "house_number": "11"
+  },
+  {
+    "uid": "469bf891-ef07-4e67-88d6-c94de7596b35",
+    "road": "Lastenkodinkuja",
+    "house_number": "2"
+  },
+  {
+    "uid": "2e3eda16-d5f8-4dd2-8f76-d67709b8cd8a",
+    "road": "Merikatu"
+  },
+  {
+    "uid": "b3dd1234-ea2d-4864-9fe6-4d01105c8a6c",
+    "road": "Lastenkodinkatu",
+    "house_number": "5"
+  },
+  {
+    "uid": "70f3ef55-a271-4708-b0db-9b62b2ffb713",
+    "road": "Merikatu",
+    "house_number": "19-21"
+  },
+  {
+    "uid": "d5503f8c-c4be-495e-b0d7-4815625aebed",
+    "road": "Lastenkodinkatu"
+  },
+  {
+    "uid": "790dd48c-399e-4ce5-98b7-1464b74e5b34",
+    "road": "Merikatu"
+  },
+  {
+    "uid": "0d74e66a-deac-46f3-ae2f-3fb2673318a3",
+    "road": "Merikatu"
+  },
+  {
+    "uid": "b51d74f7-6641-415e-9aac-96bf20d5ef48"
+  },
+  {
+    "uid": "977885b9-49e7-4529-8a27-86b50c0064ae",
+    "road": "Vuorimiehenkatu",
+    "house_number": "1"
+  },
+  {
+    "uid": "893f9d93-d615-46bc-abad-e391c41fe79b",
+    "road": "Lastenkodinkatu",
+    "house_number": "9"
+  },
+  {
+    "uid": "0d088b97-25b6-4ed1-8b9e-6cff0f1dfda6",
+    "road": "Merikatu",
+    "house_number": "15"
+  },
+  {
+    "uid": "02b10b42-eef0-4c17-b7ae-93dd0f29e4a4",
+    "road": "Merikatu",
+    "house_number": "11"
+  },
+  {
+    "uid": "1ab08e18-6c24-45e9-9a2e-a2f13374a955",
+    "road": "Kapteeninkatu",
+    "house_number": "1"
+  },
+  {
+    "uid": "bf8f264a-bab9-4a55-9b4a-8c62bcc8eea0",
+    "road": "Kapteeninkuja"
+  },
+  {
+    "uid": "cf219a99-f6da-466d-b255-aedd6d31c557",
+    "road": "Laivanvarustajankatu"
+  },
+  {
+    "uid": "dc485b8c-e8f7-4f2a-8d13-2879447209db",
+    "road": "Pietarinkatu"
+  },
+  {
+    "uid": "23aa27c1-eb9d-4b3f-8021-2a364546744e",
+    "road": "Laivanvarustajankatu"
+  },
+  {
+    "uid": "b686362e-1f5f-4904-9625-31a86afdcb24",
+    "road": "Uudenmaankatu",
+    "house_number": "15"
+  },
+  {
+    "uid": "3f59ad0e-23da-4af1-8ded-0bf5099bc133",
+    "road": "Laivanvarustajankatu",
+    "house_number": "11"
+  },
+  {
+    "uid": "0567b94a-ea31-4085-a02e-ef382c75d57d",
+    "road": "Uudenmaankatu",
+    "house_number": "11"
+  },
+  {
+    "uid": "a49e7c3c-57de-4378-8353-3d1db606c390",
+    "road": "Uudenmaankatu",
+    "house_number": "9"
+  },
+  {
+    "uid": "038b436c-e336-4a19-b57b-2bc5b953da7e",
+    "road": "Neitsytpolku"
+  },
+  {
+    "uid": "b282a31e-a473-4cc3-bbaf-4822b645b80d",
+    "road": "Laivanvarustajankatu",
+    "house_number": "6"
+  },
+  {
+    "uid": "cf0f4a7b-93ce-4b6c-8f0c-0899b6df6b89",
+    "road": "Uudenmaankatu",
+    "house_number": "9-11"
+  },
+  {
+    "uid": "ab06cec5-6a7a-484b-b583-c514ed0c9bc2",
+    "road": "Neitsytpolku"
+  },
+  {
+    "uid": "5c9bf68b-9500-471c-a04c-70f3affb5769",
+    "road": "Uudenmaankatu",
+    "house_number": "8-12"
+  },
+  {
+    "uid": "11289ab3-bd6a-49fd-a74f-f05c23787ff7",
+    "road": "Uudenmaankatu",
+    "house_number": "8-12"
+  },
+  {
+    "uid": "41e8f567-1ea6-48fa-9c51-814abe73eb12",
+    "road": "Uudenmaankatu",
+    "house_number": "25"
+  },
+  {
+    "uid": "66e07de3-3e0a-4638-a50a-17afa83bb40e",
+    "road": "Merikatu",
+    "house_number": "9"
+  },
+  {
+    "uid": "d49352c1-5bed-4afc-92a6-dc06447a3800",
+    "road": "Merikatu",
+    "house_number": "3"
+  },
+  {
+    "uid": "f51c10b6-416f-4794-b04d-e06855a57fe0",
+    "road": "Uudenmaankatu"
+  },
+  {
+    "uid": "03d97a16-cb67-42e2-ba69-5dbddc0972bd",
+    "road": "Uudenmaankatu",
+    "house_number": "32"
+  },
+  {
+    "uid": "b375a154-5a5b-4c8c-bb50-45fb69040c14",
+    "road": "Laivasillankatu"
+  },
+  {
+    "uid": "2cb0bff0-9e3d-4f28-adf0-8ee8f7e00b05",
+    "road": "Uudenmaankatu",
+    "house_number": "32"
+  },
+  {
+    "uid": "90824442-b9b4-42c2-be83-c8aabea9e986",
+    "road": "Merikatu"
+  },
+  {
+    "uid": "bbbf87e7-425c-4124-b812-9793ea146e87",
+    "road": "Neitsytpolku"
+  },
+  {
+    "uid": "ea09251d-30cb-4df1-be6f-64d89e97d765",
+    "road": "Laivanvarustajankatu",
+    "house_number": "2"
+  },
+  {
+    "uid": "e2ee21bf-601a-4ffb-81d3-779f7e0805df",
+    "road": "Uudenmaankatu",
+    "house_number": "35"
+  },
+  {
+    "uid": "77fb278b-70ce-4143-a716-443c5dac5749",
+    "road": "Uudenmaankatu",
+    "house_number": "27"
+  },
+  {
+    "uid": "5af396ca-0856-4d9a-8a04-bfe1613e19c2",
+    "road": "Uudenmaankatu",
+    "house_number": "40"
+  },
+  {
+    "uid": "cd0ff993-e06d-4805-abec-c8eaf867d4d4",
+    "road": "Neitsytpolku",
+    "house_number": "3"
+  },
+  {
+    "uid": "7d841112-d396-4405-a70c-15c49c8d2fe1",
+    "road": "Merisatamanranta"
+  },
+  {
+    "uid": "0a11b2d9-5f8e-4558-8b12-26c886de942b",
+    "road": "Fredrikinkatu",
+    "house_number": "20"
+  },
+  {
+    "uid": "3f67f817-0204-4b40-b8ac-f2cfa04ae93b",
+    "road": "Merisatamanranta"
+  },
+  {
+    "uid": "78b38ad5-2969-438a-a1f7-e26328472257",
+    "road": "Iso Roobertinkatu",
+    "house_number": "39"
+  },
+  {
+    "uid": "385b6e9e-12b9-417d-9a29-ab13a53b9fa7",
+    "road": "Merisatamanranta"
+  },
+  {
+    "uid": "2e4770f6-55a4-4eb8-a9fd-d167f8436df5",
+    "road": "Iso Roobertinkatu",
+    "house_number": "41"
+  },
+  {
+    "uid": "ce19af8b-78c9-42d4-a6f7-ec85e3e0eac0",
+    "road": "Vuorimiehenkatu",
+    "house_number": "7"
+  },
+  {
+    "uid": "1d7aff32-a16a-457a-89c0-6347aed09bdf",
+    "road": "Iso Roobertinkatu",
+    "house_number": "45"
+  },
+  {
+    "uid": "a692055b-4597-40e3-9480-c9f2d01adf1b",
+    "road": "Vuorimiehenkatu"
+  },
+  {
+    "uid": "b1ae9296-21ff-461b-851f-9886213f2888",
+    "road": "Kivenhakkaajankatu",
+    "house_number": "1"
+  },
+  {
+    "uid": "8e2526ea-bb25-4811-ae59-eeb9a952dbb8",
+    "road": "Iso Roobertinkatu",
+    "house_number": "48-50"
+  },
+  {
+    "uid": "1ba95a17-8187-4de1-aeda-5c97df9ba03a",
+    "road": "Vuorimiehenkatu",
+    "house_number": "7"
+  },
+  {
+    "uid": "cee7d8c8-51d2-486c-80b6-dc306acc0cbf",
+    "road": "Tehtaankatu",
+    "house_number": "1 B"
+  },
+  {
+    "uid": "fc3c8924-6be8-4a5c-b677-b2a334e9470c",
+    "road": "Punavuorenkatu"
+  },
+  {
+    "uid": "295a93a8-7e5f-407d-999c-2bd792ac73f6",
+    "road": "Fredrikintori"
+  },
+  {
+    "uid": "898d607a-2a49-4548-9e51-874c52caca43",
+    "road": "Punavuorenkatu"
+  },
+  {
+    "uid": "f9b7cab7-b55f-4982-af84-49efcb7ea6a5",
+    "road": "Albertinkatu"
+  },
+  {
+    "uid": "370f44c0-601b-4a45-a48a-b5038c539187",
+    "road": "Punavuorenkatu",
+    "house_number": "23"
+  },
+  {
+    "uid": "952bfb60-8bac-4e12-9ce1-a10da743aeb9",
+    "road": "Punavuorenkatu"
+  },
+  {
+    "uid": "d597c792-7c88-4f70-8f2f-520ddbadafa4",
+    "road": "Vuorimiehenkatu",
+    "house_number": "1"
+  },
+  {
+    "uid": "76778947-9e58-4063-8ac0-5ef981629ae9",
+    "road": "Vuorimiehenkatu",
+    "house_number": "1a"
+  },
+  {
+    "uid": "c7157bcc-7d8b-404a-b4d1-974883d043a8",
+    "road": "Punavuorenkatu",
+    "house_number": "16"
+  },
+  {
+    "uid": "d9a30362-3136-4149-888b-f351a56f4f11",
+    "road": "Punavuorenkatu",
+    "house_number": "11"
+  },
+  {
+    "uid": "6d6dc6fd-53a7-4ec3-9b21-b74f4b7697cc",
+    "road": "Ullankatu"
+  },
+  {
+    "uid": "4f47a9fe-86c6-420f-8742-729e568ee761",
+    "road": "Punavuorenkatu",
+    "house_number": "12"
+  },
+  {
+    "uid": "37f4e3d1-a7bf-48ba-ab21-db3058e0435e",
+    "road": "Punavuorenkatu",
+    "house_number": "16"
+  },
+  {
+    "uid": "1928ddf5-5e1c-4d12-875f-28ef55c23564",
+    "road": "Ullankatu",
+    "house_number": "3"
+  },
+  {
+    "uid": "2fbaeac9-aa18-47f8-8525-19876f55a965",
+    "road": "Punavuorenkatu",
+    "house_number": "23"
+  },
+  {
+    "uid": "80dae1a9-87fc-49ca-b838-dff5c284b54a",
+    "road": "Laivasillankatu",
+    "house_number": "6-8"
+  },
+  {
+    "uid": "c9bd5a79-99bd-4968-ad38-b1d99894c2c2",
+    "road": "Muukalaiskatu",
+    "house_number": "1"
+  },
+  {
+    "uid": "102e9b47-cb7b-478e-a408-2c7a632ecdad",
+    "road": "Ratakatu",
+    "house_number": "3"
+  },
+  {
+    "uid": "8816f6e0-d301-4f3b-96e3-cde6aaf1e48f",
+    "road": "Muukalaiskatu",
+    "house_number": "3"
+  },
+  {
+    "uid": "2460bc2a-4508-4ae4-a54b-e4bf6e8567de",
+    "road": "Muukalaiskatu",
+    "house_number": "1"
+  },
+  {
+    "uid": "839fce8f-43bf-4f51-8961-f9abfe806e03",
+    "road": "Ratakatu",
+    "house_number": "3"
+  },
+  {
+    "uid": "9d0e6373-1603-4639-8930-220dece2bfef",
+    "road": "Ratakatu",
+    "house_number": "9"
+  },
+  {
+    "uid": "04a89b07-0c19-40f4-bdc3-b7d122298b9e",
+    "road": "Ratakatu",
+    "house_number": "3"
+  },
+  {
+    "uid": "9d38e808-5fbf-4e30-aa0d-1825cd917950",
+    "road": "Muukalaiskatu"
+  },
+  {
+    "uid": "f30ae557-d52f-4540-8afc-f24287978ca1",
+    "road": "Ratakatu"
+  },
+  {
+    "uid": "d98179a4-e3dd-4a76-af32-257ae862dcb6",
+    "road": "Laivasillankatu"
+  },
+  {
+    "uid": "8c584952-faad-48ce-baef-6680401863b3",
+    "road": "Ratakatu",
+    "house_number": "27"
+  },
+  {
+    "uid": "a5668208-5043-489e-948e-3f2ac53f5697",
+    "road": "Ratakatu",
+    "house_number": "10"
+  },
+  {
+    "uid": "9148e7fd-4aec-4b09-928c-eb3b30aed803",
+    "road": "Laivurinrinne"
+  },
+  {
+    "uid": "708ef139-66c6-497e-9621-75f7dc8c9d77",
+    "road": "Laivurinrinne"
+  },
+  {
+    "uid": "a0daa050-6ee5-4bc7-a4c9-501ec87fd9fd",
+    "road": "Merimiehenkatu"
+  },
+  {
+    "uid": "f98ca333-49d6-4067-b36c-06e59bb44715",
+    "road": "Merimiehenkatu"
+  },
+  {
+    "uid": "903cdbe3-1081-4821-98d6-8b3bccbcc435",
+    "road": "Merimiehenkatu",
+    "house_number": "27"
+  },
+  {
+    "uid": "bbe09b17-2298-4b0c-9487-2d0f707729a1",
+    "road": "Tehtaankatu",
+    "house_number": "6"
+  },
+  {
+    "uid": "aa4522b0-d9ea-4bab-9920-6b6336463134",
+    "road": "Tehtaankatu",
+    "house_number": "1 B"
+  },
+  {
+    "uid": "d4445c38-84e4-48f1-86f4-6deb22f9ac40",
+    "road": "Tehtaankatu",
+    "house_number": "10"
+  },
+  {
+    "uid": "61ee3a0a-6d84-4288-8cd0-15bbf13f30f2",
+    "road": "Pietarinkatu"
+  },
+  {
+    "uid": "42d20a86-5666-40e8-953c-5415f1ba2577",
+    "road": "Pietarinkatu"
+  },
+  {
+    "uid": "b646803b-c624-4555-9c10-a93df44be563",
+    "road": "Raatimiehenkatu"
+  },
+  {
+    "uid": "b32b5acf-c89d-4ce3-b43c-7ed02a0418e5",
+    "road": "Raatimiehenkatu"
+  },
+  {
+    "uid": "6ec54295-d503-461a-8709-39f11130d236",
+    "road": "Raatimiehenkatu"
+  },
+  {
+    "uid": "e9d38d18-0016-4831-84ad-003e1b4ad12f",
+    "road": "Raatimiehenkatu"
+  },
+  {
+    "uid": "18bd6b34-9959-482c-8fd9-c54668c91251",
+    "road": "Puistokatu",
+    "house_number": "1a"
+  },
+  {
+    "uid": "a2914fd3-5946-4cd3-8e0a-53b9a915e560",
+    "road": "Puistokatu",
+    "house_number": "1B"
+  },
+  {
+    "uid": "66b7e761-2bbf-4be9-a7d1-66397627115e",
+    "road": "Puistokatu",
+    "house_number": "3"
+  },
+  {
+    "uid": "796c8c1b-69d7-4b12-8ee0-453b703df4f5",
+    "road": "Puistokatu"
+  },
+  {
+    "uid": "0d5a5ccb-6be3-46d7-975e-891374c5aef9",
+    "road": "Puistokatu",
+    "house_number": "5"
+  },
+  {
+    "uid": "f306ec29-40f3-4281-b56b-f06694024bfc",
+    "road": "Puistokatu",
+    "house_number": "6"
+  },
+  {
+    "uid": "eed284fd-810a-477a-be71-0381fec23029",
+    "road": "Puistokatu",
+    "house_number": "11b"
+  },
+  {
+    "uid": "075c9ea8-0822-4347-a4a1-c6284eb9eeba",
+    "road": "Puistokatu"
+  },
+  {
+    "uid": "d9c6e1b9-c4b6-4517-9828-e83b2d2e461c",
+    "road": "Perämiehenkatu"
+  },
+  {
+    "uid": "b78f4db4-8852-48e8-a8c4-fda91c4f500e",
+    "road": "Itäinen Puistotie",
+    "house_number": "14 B"
+  },
+  {
+    "uid": "05c4fcf2-fa73-40f8-af8f-66f0985526cc",
+    "road": "Merimiehenkatu"
+  },
+  {
+    "uid": "6d3f6c4b-93ae-4a0b-ae23-9ff956746ed8",
+    "road": "Merimiehenkatu"
+  },
+  {
+    "uid": "8935a46e-fcf6-4ad4-a8f4-d740459e5d7a",
+    "road": "Pursimiehenkatu",
+    "house_number": "11"
+  },
+  {
+    "uid": "93fcf94b-1464-40bd-a1da-66d869fca27f",
+    "road": "Olympiaranta"
+  },
+  {
+    "uid": "38698dd5-eb91-483c-a20d-11204b252ff6",
+    "road": "Pursimiehenkatu",
+    "house_number": "8"
+  },
+  {
+    "uid": "ec9ed2cc-3a87-4c3d-82e3-faa2194fc015",
+    "road": "Pursimiehenkatu"
+  },
+  {
+    "uid": "f2dbfb25-b74c-4c54-8a6e-00feb38821c6",
+    "road": "Ehrenströmintie",
+    "house_number": "14"
+  },
+  {
+    "uid": "1fd8aea5-255a-4422-89b5-7e47ddbdebdd",
+    "road": "Pursimiehenkatu",
+    "house_number": "4B"
+  },
+  {
+    "uid": "4a3ac9d4-8833-4e31-8b72-828515fea8c6",
+    "road": "Pursimiehenkatu",
+    "house_number": "4B"
+  },
+  {
+    "uid": "036d0253-0904-4e0c-a05f-eb895595d972",
+    "road": "Pursimiehenkatu",
+    "house_number": "4"
+  },
+  {
+    "uid": "acef41dd-fa13-4ac1-9efe-e31302d6d72e",
+    "road": "Pursimiehenkatu"
+  },
+  {
+    "uid": "4cc2ac3d-e482-44e9-a1e2-b3d30a7e6203",
+    "road": "Albertinkatu",
+    "house_number": "15"
+  },
+  {
+    "uid": "aa70c92c-b26d-4fb7-b084-1b0b4d1c73f5",
+    "road": "Pursimiehenkatu",
+    "house_number": "16"
+  },
+  {
+    "uid": "a4e7837a-4fbe-470a-b24d-6dd0510b070c",
+    "road": "Itäinen Puistotie",
+    "house_number": "8"
+  },
+  {
+    "uid": "7e71e7b7-30c1-48c4-aabc-22701d96edbf",
+    "road": "Pursimiehenkatu",
+    "house_number": "18"
+  },
+  {
+    "uid": "92f50004-9ec3-4349-893d-450068c9f01d",
+    "road": "Kalliolinnantie",
+    "house_number": "5"
+  },
+  {
+    "uid": "f2653590-4b18-43ca-9bc6-c977f1e025dd",
+    "road": "Pursimiehenkatu",
+    "house_number": "27"
+  },
+  {
+    "uid": "5704c9f7-abd1-4864-8c43-eb82bca79d6f",
+    "road": "Kalliolinnantie",
+    "house_number": "5"
+  },
+  {
+    "uid": "35769f3c-195a-4e54-bb4b-f43dcfd76aee",
+    "road": "Pursimiehenkatu"
+  },
+  {
+    "uid": "3e3075cc-8920-477a-93d6-55fcf8eba585",
+    "road": "Kalliolinnantie",
+    "house_number": "5"
+  },
+  {
+    "uid": "4d6de55d-09ea-4835-8a8f-e9bbe3533adf",
+    "road": "Porrastie"
+  },
+  {
+    "uid": "6ad99bdb-068c-47b7-a35c-d58f7444151d",
+    "road": "Pursimiehenkatu"
+  },
+  {
+    "uid": "86b9dd1f-cba1-4a63-8b50-d7118983f800",
+    "road": "Kalliolinnantie",
+    "house_number": "10"
+  },
+  {
+    "uid": "70fefa93-0571-4d43-959a-e891d97bb186",
+    "road": "Sepänkatu"
+  },
+  {
+    "uid": "564a3782-b903-4fb5-b22c-198d30971416",
+    "road": "Pohjoisranta"
+  },
+  {
+    "uid": "b1649bfa-f1e6-4b2b-9ec1-e4bd1db574ed",
+    "road": "Kalliolinnantie",
+    "house_number": "3"
+  },
+  {
+    "uid": "d34c51f0-8d23-445e-8bd0-0e0ac8ed3f56",
+    "road": "Sepänkatu"
+  },
+  {
+    "uid": "1adcd6bb-fb36-4227-9307-bbb6ca4f9c29",
+    "road": "Kalliolinnantie"
+  },
+  {
+    "uid": "0e2951a4-22b5-4892-b734-ba8ff1f7e172",
+    "road": "Sepänkatu",
+    "house_number": "7"
+  },
+  {
+    "uid": "b974b810-d9f3-4e62-86c5-6e2992953900",
+    "road": "Kalliolinnantie",
+    "house_number": "4B"
+  },
+  {
+    "uid": "62e1fbd1-cd58-42ea-b8ec-fe3c63ecd9d1",
+    "road": "Sepänkatu",
+    "house_number": "7"
+  },
+  {
+    "uid": "4e5c2dc2-64b6-4c71-ba6d-6b3da2580569",
+    "road": "Itäinen Puistotie",
+    "house_number": "5"
+  },
+  {
+    "uid": "7e7c935f-f5e9-41be-a2b8-ea86cfcd629e",
+    "road": "Sepänkatu"
+  },
+  {
+    "uid": "b77ef7bf-0a04-4837-b528-aa7d642413c8",
+    "road": "Sepänkatu"
+  },
+  {
+    "uid": "cb8ce627-4441-4110-87ab-ce9d74c7d6b7",
+    "road": "Sepänkatu"
+  },
+  {
+    "uid": "131554ec-2453-4db6-bfec-2992b3d4df9f",
+    "road": "Sepänkatu",
+    "house_number": "17"
+  },
+  {
+    "uid": "d96a6b42-7360-42f7-af85-f0643dd419e5",
+    "road": "Myllytie",
+    "house_number": "3"
+  },
+  {
+    "uid": "62b90e33-fbb7-408c-8134-82faf63e9247",
+    "road": "Annankatu",
+    "house_number": "10"
+  },
+  {
+    "uid": "ebe1400d-6a61-436e-ae08-6b458a92fae9",
+    "road": "Oikotie"
+  },
+  {
+    "uid": "0561adf4-11a8-4208-aaa9-6c071fe455ca",
+    "road": "Annankatu",
+    "house_number": "6"
+  },
+  {
+    "uid": "48995f73-8724-4feb-8591-627a6b0be669",
+    "road": "Annankatu",
+    "house_number": "5"
+  },
+  {
+    "uid": "a30ee71a-5940-499f-b061-c44171fb93ad",
+    "road": "Itäinen Puistotie"
+  },
+  {
+    "uid": "e5dff506-89b2-43c8-997d-9b5700b63c5f",
+    "road": "Uudenmaankatu"
+  },
+  {
+    "uid": "fe60fed3-0ada-43ca-97b4-2b8ac9d294ff",
+    "road": "Itäinen Puistotie",
+    "house_number": "17"
+  },
+  {
+    "uid": "eada6986-4f0e-41e6-a10d-593d3733c81b",
+    "road": "Uudenmaankatu"
+  },
+  {
+    "uid": "215004bd-f220-46c2-9391-010ed246d9ac",
+    "road": "Iso Roobertinkatu",
+    "house_number": "18"
+  },
+  {
+    "uid": "a4db9f65-85f3-46d6-b600-8637ad157fac",
+    "road": "Annankatu",
+    "house_number": "1"
+  },
+  {
+    "uid": "13267daf-d864-47ef-8890-0b7fc4a455fb",
+    "road": "Annankatu",
+    "house_number": "3"
+  },
+  {
+    "uid": "b13f8d2f-d1e7-40ad-933f-5eabf1cb5dbf",
+    "road": "Annankatu",
+    "house_number": "3"
+  },
+  {
+    "uid": "a7ebe50a-5e01-4443-8e23-fb59f2afcc5c",
+    "road": "Albertinkatu",
+    "house_number": "9"
+  },
+  {
+    "uid": "d7c9310d-9f12-40f2-b829-cfd42ee2ac58",
+    "road": "Fredrikinkatu",
+    "house_number": "31"
+  },
+  {
+    "uid": "a2b72240-7853-4a5f-b6f7-e86504e9824b",
+    "road": "Fredrikinkatu",
+    "house_number": "23"
+  },
+  {
+    "uid": "aef2d214-fc51-4392-9524-84bb2f05b545",
+    "road": "Itäinen Puistotie"
+  },
+  {
+    "uid": "ba256bae-c59f-4d30-97aa-31f0ecee05ee",
+    "road": "Fredrikinkatu",
+    "house_number": "23"
+  },
+  {
+    "uid": "be9e5397-d5fe-4182-b7b3-fb0cb00b74a1",
+    "road": "Fredrikinkatu",
+    "house_number": "25"
+  },
+  {
+    "uid": "6442ccbc-9492-4d7e-9b4a-e4cd7bcb7a54",
+    "road": "Fredrikinkatu",
+    "house_number": "14"
+  },
+  {
+    "uid": "66930e32-b08c-4a3d-a7ef-0da39ea20e1a",
+    "road": "Fredrikinkatu"
+  },
+  {
+    "uid": "cbb25ea6-6ac8-42f3-bfd3-cf1715fcdd08",
+    "road": "Ehrenströmintie"
+  },
+  {
+    "uid": "56101b99-5b2d-4c8d-8fba-d4a6d4d07cfd",
+    "road": "Albertinkatu",
+    "house_number": "19"
+  },
+  {
+    "uid": "1beadd2c-eea4-4bc0-a1e8-ff5f2ed16519",
+    "road": "Albertinkatu",
+    "house_number": "26-28"
+  },
+  {
+    "uid": "e0ab053c-3f19-4a63-9765-f45b27500333",
+    "road": "Ehrenströmintie",
+    "house_number": "3"
+  },
+  {
+    "uid": "9540e403-f447-4f31-8f3d-b050bcce45df",
+    "road": "Albertinkatu",
+    "house_number": "16"
+  },
+  {
+    "uid": "219e72c5-5421-4b86-8bb8-7db18017b331",
+    "road": "Albertinkatu",
+    "house_number": "16"
+  },
+  {
+    "uid": "51814162-d8b9-43bd-8aba-174db943772a",
+    "road": "Ehrenströmintie"
+  },
+  {
+    "uid": "19632de3-e1a2-4224-b3c6-4cd905a46bac",
+    "road": "Ehrenströmintie"
+  },
+  {
+    "uid": "98be5784-fa5e-440e-b2fe-2f44dfbc8d05",
+    "road": "Albertinkatu"
+  },
+  {
+    "uid": "a30dfa2d-8232-4e36-b985-87f6b72660bc",
+    "road": "Ehrenströmintie"
+  },
+  {
+    "uid": "e3ed62bb-0b6b-4c1c-842f-bdff578d1454",
+    "road": "Albertinkatu",
+    "house_number": "12"
+  },
+  {
+    "uid": "af1c1e5b-f96d-47e5-966f-e609ddbc85e1",
+    "road": "Ehrenströmintie"
+  },
+  {
+    "uid": "54fb98cc-71cb-4858-8a26-da1bdce289e6",
+    "road": "Merimiehenkatu"
+  },
+  {
+    "uid": "dbb91737-a293-4b94-a384-314da5b56cb7",
+    "road": "Ehrenströmintie"
+  },
+  {
+    "uid": "35475791-2cbd-4469-93f6-51dcf9da9afb",
+    "road": "Albertinkatu"
+  },
+  {
+    "uid": "b19c4c29-e5db-4982-b9b3-409a1c69143c",
+    "road": "Albertinkatu",
+    "house_number": "1"
+  },
+  {
+    "uid": "f1b37ed5-bdb7-4fdc-ab8f-e7092ea39de5",
+    "road": "Kankurinkatu",
+    "house_number": "8"
+  },
+  {
+    "uid": "aa6c43cc-1ec0-45e9-8658-4f91872b9926",
+    "road": "Kankurinkatu",
+    "house_number": "4"
+  },
+  {
+    "uid": "e533093d-b8c2-4b7c-95dc-bf4233201dae",
+    "road": "Kankurinkatu",
+    "house_number": "1"
+  },
+  {
+    "uid": "126134e5-3d8a-4989-8c5e-453669cad2f9",
+    "road": "Perämiehenkatu"
+  },
+  {
+    "uid": "7979736f-62aa-42de-88a5-1463cadb66e4",
+    "road": "Perämiehenkatu",
+    "house_number": "13"
+  },
+  {
+    "uid": "626ac77a-aa62-4799-bb04-949c7c0cc916",
+    "road": "Perämiehenkatu"
+  },
+  {
+    "uid": "b4df4b97-a25e-4aeb-8cff-d9286911af24",
+    "road": "Perämiehenkatu"
+  },
+  {
+    "uid": "a980d856-1517-44bd-bb3f-f6298b7b53fc",
+    "road": "Perämiehenkatu"
+  },
+  {
+    "uid": "45013cf8-3b4c-41ba-bdab-e36cfd63b6ea",
+    "road": "Pursimiehenkatu"
+  },
+  {
+    "uid": "a5e8a03e-e614-4028-8d91-523b7dcff4cf",
+    "road": "Pursimiehenkatu"
+  },
+  {
+    "uid": "9526fe9e-1437-4a09-9938-a1e5dee1daac",
+    "road": "Telakkakatu"
+  },
+  {
+    "uid": "759d8303-7b94-4990-a956-24ece8c0d3d5",
+    "road": "Hietalahdenranta",
+    "house_number": "3"
+  },
+  {
+    "uid": "0117225e-8019-438c-962a-b8526e99cf36",
+    "road": "Ehrenströmintie"
+  },
+  {
+    "uid": "38c41b5d-bdbe-466b-8df7-34d46c0b28bc",
+    "road": "Hietalahdenranta",
+    "house_number": "5c"
+  },
+  {
+    "uid": "cd087b3c-3639-4dad-84a6-ed953ac22251",
+    "road": "Hietalahdenranta",
+    "house_number": "6"
+  },
+  {
+    "uid": "ea6e1191-2fa7-487c-92f1-79d8709ece21",
+    "road": "Ehrenströmintie"
+  },
+  {
+    "uid": "a235aa47-048d-4a4a-ab32-4aaf4c81f52a"
+  },
+  {
+    "uid": "00ba2442-d427-4c7b-a6fc-9349b79f0ef5"
+  },
+  {
+    "uid": "ef399f01-118d-4c46-9312-33d839c75f4e",
+    "road": "Iso Puistotie",
+    "house_number": "1"
+  },
+  {
+    "uid": "96219df3-10da-48e8-acd7-394f0979ef47"
+  },
+  {
+    "uid": "08323f43-02e2-41d5-9903-7e2c9f9f1ef3",
+    "road": "Tehtaankatu"
+  },
+  {
+    "uid": "e342fd19-5842-4a5e-b4e5-faa8dadcd20f",
+    "road": "Kaivohuoneenrinne"
+  },
+  {
+    "uid": "5120ddb9-9b86-4080-867e-29ca47baef65",
+    "road": "Tehtaankatu",
+    "house_number": "38"
+  },
+  {
+    "uid": "d8bdbf1b-9c8d-4b70-9487-bce7d58aaea3",
+    "road": "Tehtaankatu",
+    "house_number": "36"
+  },
+  {
+    "uid": "23000726-c08e-459f-ba07-1d9dec7fd578",
+    "road": "Tehtaankatu"
+  },
+  {
+    "uid": "fe94a939-630a-416f-bb7a-b8d0ed390dcd",
+    "road": "Tehtaankatu",
+    "house_number": "23 A"
+  },
+  {
+    "uid": "ba6ebfc5-69f2-4768-94e1-4c6d07bd3e76",
+    "road": "Tehtaankatu",
+    "house_number": "34a"
+  },
+  {
+    "uid": "bcb2066a-e0cc-4720-80a7-2cb782fa133e",
+    "road": "Tehtaankatu",
+    "house_number": "34a"
+  },
+  {
+    "uid": "5aed10ee-dc51-4b15-9d38-591c916a1ac7",
+    "road": "Tehtaankatu",
+    "house_number": "23"
+  },
+  {
+    "uid": "b24bbb06-2d27-46a4-9cb2-9bb836bbd0ba",
+    "road": "Kaivohuoneenrinne"
+  },
+  {
+    "uid": "69226c01-389e-47a7-95c8-6f3acbed2601",
+    "road": "Tehtaankatu",
+    "house_number": "32cd"
+  },
+  {
+    "uid": "f2fd78d3-e14f-4b3f-ae1b-2b2f75377ce9",
+    "road": "Iso Puistotie"
+  },
+  {
+    "uid": "73b079a7-eda7-4236-90cf-75d7e1cca76f",
+    "road": "Tehtaankatu"
+  },
+  {
+    "uid": "0b3f401f-0861-4b9f-ad4f-9cb7ba69f630",
+    "road": "Speranskintie",
+    "house_number": "3"
+  },
+  {
+    "uid": "65ae4d5e-8fb4-4927-8c22-df47a4551b2e",
+    "road": "Speranskintie"
+  },
+  {
+    "uid": "224931fc-5431-4981-a456-0ec59b64362c",
+    "road": "Laivurinkatu",
+    "house_number": "33"
+  },
+  {
+    "uid": "29dd45b9-4626-4f73-bf38-8000a29e898a",
+    "road": "Speranskintie",
+    "house_number": "2-4"
+  },
+  {
+    "uid": "d8fe342a-392b-44b9-84d8-30ce840120d0",
+    "road": "Laivurinkatu"
+  },
+  {
+    "uid": "0b88138d-832d-4b2e-b561-dd836da51e78",
+    "road": "Laivurinkatu",
+    "house_number": "37"
+  },
+  {
+    "uid": "161966b5-7410-4dd7-b0c2-ae7f0f1c396c",
+    "road": "Sepänkatu"
+  },
+  {
+    "uid": "2615d944-093f-488b-afba-6c4377fdeeca",
+    "road": "Laivurinkatu",
+    "house_number": "10"
+  },
+  {
+    "uid": "981ac4e3-1cbe-490a-a913-b02910304365",
+    "road": "Laivurinkatu",
+    "house_number": "10"
+  },
+  {
+    "uid": "f8085af0-9519-49af-b132-d0a04d497c39",
+    "road": "Laivurinkatu",
+    "house_number": "10"
+  },
+  {
+    "uid": "a6bc1e1e-e4d0-4046-99ab-86ad8d1432a6",
+    "road": "Ehrensvärdintie"
+  },
+  {
+    "uid": "b0693d6b-62c3-4f6b-ad96-a4cbc614a225",
+    "road": "Ehrensvärdintie"
+  },
+  {
+    "uid": "43ad0b79-9c0e-4adb-882e-10afc57b8ff0",
+    "road": "Merikannontie"
+  },
+  {
+    "uid": "70c9b611-37ac-4d68-accf-cc7c74f46823",
+    "road": "Rehbinderintie"
+  },
+  {
+    "uid": "d5e0aa1b-653f-4226-b74a-99277380881f",
+    "road": "Rehbinderintie",
+    "house_number": "12"
+  },
+  {
+    "uid": "63f8238c-b1b6-4bd3-ab70-3399e060d588",
+    "road": "Kesäkatu",
+    "house_number": "2"
+  },
+  {
+    "uid": "119890e7-b2ac-4af4-b706-f582b76e5c58",
+    "road": "Pohjoinen Hesperiankatu",
+    "house_number": "33A"
+  },
+  {
+    "uid": "240185f5-e8e0-4fb1-b8cd-50f48a1b5809",
+    "road": "Pohjoinen Hesperiankatu",
+    "house_number": "33A"
+  },
+  {
+    "uid": "18e4f7c2-1fd4-4858-ae38-ed1d17309e0e",
+    "road": "Edelfeltintie",
+    "house_number": "10"
+  },
+  {
+    "uid": "352394f7-a05d-47e0-8f00-e1466420af41",
+    "road": "Edelfeltintie",
+    "house_number": "14"
+  },
+  {
+    "uid": "6290df77-6aed-4f31-b48c-841e9a5fa15a",
+    "road": "Pohjoinen Hesperiankatu"
+  },
+  {
+    "uid": "f4784137-6cf2-42be-b4b5-b88f4156dff2",
+    "road": "Edelfeltintie",
+    "house_number": "5-7"
+  },
+  {
+    "uid": "ef193212-b5c0-493d-851b-3bfe79c6afe3",
+    "road": "Pohjoinen Hesperiankatu"
+  },
+  {
+    "uid": "1e43cbd2-fda4-4be8-9aa7-5efd83823f51",
+    "road": "Pohjoinen Hesperiankatu"
+  },
+  {
+    "uid": "3f045ccd-db3c-4902-8137-ce6d4296ad6c",
+    "road": "Pohjoinen Hesperiankatu",
+    "house_number": "5"
+  },
+  {
+    "uid": "a3bc092b-1553-4ae6-a958-8849d464a8dd",
+    "road": "Pohjoinen Hesperiankatu"
+  },
+  {
+    "uid": "71f35d9d-786f-443d-956c-56bad971557b",
+    "road": "Pohjoinen Hesperiankatu",
+    "house_number": "5"
+  },
+  {
+    "uid": "a357211c-c355-450c-a25f-e0cd3f3e8ee2",
+    "road": "Pohjoinen Hesperiankatu"
+  },
+  {
+    "uid": "89dcd769-88d6-4aaa-9927-9372227298b2",
+    "road": "Pohjoinen Hesperiankatu"
+  },
+  {
+    "uid": "161229cb-8665-469f-b32e-08e46d7a63cd",
+    "road": "Engelinaukio"
+  },
+  {
+    "uid": "b8f8320f-c196-4607-a1cb-eba55c73a335",
+    "road": "Engelinaukio",
+    "house_number": "5"
+  },
+  {
+    "uid": "56fcd78b-151d-435b-a3a2-69b94373d561",
+    "road": "Pohjoinen Hesperiankatu"
+  },
+  {
+    "uid": "e23fc37f-3b0e-4a57-a151-dfdbe98bf08c",
+    "road": "Pohjoinen Hesperiankatu",
+    "house_number": "17"
+  },
+  {
+    "uid": "0d6c5088-a142-44af-a51f-4e00b6ccc6f7",
+    "road": "Engelinaukio"
+  },
+  {
+    "uid": "3144c6ab-8451-40fa-9e63-69a201c71647",
+    "road": "Pohjoinen Hesperiankatu",
+    "house_number": "21"
+  },
+  {
+    "uid": "4cee8596-fce6-4077-b4dc-95b535e1b9e3",
+    "road": "Engelinaukio",
+    "house_number": "8"
+  },
+  {
+    "uid": "a6eae75c-f8df-442a-bf95-daac9f2625f9",
+    "road": "Pohjoinen Hesperiankatu",
+    "house_number": "21"
+  },
+  {
+    "uid": "ad2c8d52-e35c-449a-8bff-d6f048b2b7e8",
+    "road": "Engelinaukio"
+  },
+  {
+    "uid": "2f36c9be-94aa-454d-af22-e78ccc845f70",
+    "road": "Engelinaukio",
+    "house_number": "4"
+  },
+  {
+    "uid": "ba3e3375-9f51-4c26-ab7b-04eed37debe4",
+    "road": "Rehbinderintie"
+  },
+  {
+    "uid": "5fae8955-aea1-4726-9334-4c91f0e4d5e4",
+    "road": "Pohjoinen Hesperiankatu"
+  },
+  {
+    "uid": "3fbfd2fd-41e8-47d5-b31a-186e9de2e996",
+    "road": "Rehbinderintie",
+    "house_number": "15"
+  },
+  {
+    "uid": "d4181c20-2d20-4974-ad9d-d5c66bb96d6d",
+    "road": "Armfeltintie",
+    "house_number": "20"
+  },
+  {
+    "uid": "b1f3e5c5-8c65-4c20-adc7-5f34680ac207",
+    "road": "Armfeltintie",
+    "house_number": "13"
+  },
+  {
+    "uid": "54da2cd6-9b46-4a11-aeea-33f31630a24e",
+    "road": "Pohjoinen Hesperiankatu"
+  },
+  {
+    "uid": "4c3f587c-6c70-42e2-bd85-23d38dfdffa1",
+    "road": "Armfeltintie",
+    "house_number": "16"
+  },
+  {
+    "uid": "9d7e7b09-91b9-40b2-b941-f6f963e8ac41",
+    "road": "Pohjoinen Hesperiankatu"
+  },
+  {
+    "uid": "1f7d3c78-b7c1-42d7-867b-1062d7df3fca",
+    "road": "Armfeltintie"
+  },
+  {
+    "uid": "2809b3a9-b0ea-469e-aa4a-82c4aa2914d6",
+    "road": "Välskärinkatu"
+  },
+  {
+    "uid": "495ce6f8-dc7e-4efd-adbd-a7eccc18d1bb",
+    "road": "Välskärinkatu",
+    "house_number": "8"
+  },
+  {
+    "uid": "66a9a1f4-ddd6-46a0-9352-965efb2cf35a",
+    "road": "Välskärinkatu"
+  },
+  {
+    "uid": "19a061c8-4722-4384-9c81-99aa5d8d391e",
+    "road": "Tykistönkatu"
+  },
+  {
+    "uid": "647ab8ce-0002-4a41-8c0e-27972a8593a3",
+    "road": "Välskärinkatu"
+  },
+  {
+    "uid": "c1bc0249-1177-48ca-b336-6e36b29e3953",
+    "road": "Engelinaukio",
+    "house_number": "17"
+  },
+  {
+    "uid": "d3a29388-82cf-4f75-99f8-199c4cda03fa",
+    "road": "Välskärinkatu"
+  },
+  {
+    "uid": "0354d1c3-03dd-4b1a-8955-ad7ed61fb974",
+    "road": "Välskärinkatu"
+  },
+  {
+    "uid": "5f4ef1ef-ce2a-4b9b-b54b-e82dcc006126",
+    "road": "Armfeltintie",
+    "house_number": "11"
+  },
+  {
+    "uid": "6d7b90c6-8ef0-447b-b286-d35989d34d1b",
+    "road": "Välskärinkatu"
+  },
+  {
+    "uid": "90e8c011-3e6a-4104-964c-1e4a0935db17",
+    "road": "Armfeltintie",
+    "house_number": "14"
+  },
+  {
+    "uid": "91cf9a7a-6b48-4491-9a15-29b2c42daa03",
+    "road": "Armfeltintie"
+  },
+  {
+    "uid": "566ca2af-4f3f-49f7-b029-6bc5971d3b10",
+    "road": "Sibeliuksenkatu"
+  },
+  {
+    "uid": "8b1f1546-859c-4ed2-854e-bff823724e90",
+    "road": "Armfeltintie",
+    "house_number": "10"
+  },
+  {
+    "uid": "7d363051-b447-452b-9a94-143344f86c86",
+    "road": "Sibeliuksenkatu"
+  },
+  {
+    "uid": "8d6accbf-6e51-43b4-8d39-5c6e3cfe95a8",
+    "road": "Armfeltintie",
+    "house_number": "1"
+  },
+  {
+    "uid": "2d033615-8eec-4e47-879a-0af52085ab4e",
+    "road": "Sibeliuksenkatu"
+  },
+  {
+    "uid": "2f3ae093-fa8a-4594-a109-4f5ef23353e9",
+    "road": "Välskärinkatu"
+  },
+  {
+    "uid": "8f6350b5-394e-422e-a805-2b7dcbce987a",
+    "road": "Döbelninkatu",
+    "house_number": "6"
+  },
+  {
+    "uid": "0b23b6b5-0145-403e-82ab-fcf0e80b295e",
+    "road": "Sandelsinkatu"
+  },
+  {
+    "uid": "cd8f3edf-29ce-47e2-a5a3-5b4c99667c7b",
+    "road": "Sandelsinkatu",
+    "house_number": "6"
+  },
+  {
+    "uid": "7f0092ef-6ea8-4ce8-95e2-fe807d78ad81",
+    "road": "Sandelsinkatu"
+  },
+  {
+    "uid": "8d35ad50-cf98-491a-aa0b-68238156b484",
+    "road": "Töölöntori"
+  },
+  {
+    "uid": "8ea4229c-d84a-4caf-9aef-df23498df795",
+    "road": "Rehbinderintie",
+    "house_number": "7"
+  },
+  {
+    "uid": "2d81cc86-ab4f-456a-91e8-bfb6b952031d",
+    "road": "Rehbinderintie",
+    "house_number": "1"
+  },
+  {
+    "uid": "a7fb4ce3-c882-46ff-ab53-487a65b2c6c9",
+    "road": "Juhani Ahon tie"
+  },
+  {
+    "uid": "15e0ce08-ee37-4241-abe7-69bab78efbb7",
+    "road": "Runeberginkatu",
+    "house_number": "55a"
+  },
+  {
+    "uid": "677070da-f8e8-4003-85c3-3bf35144d45b",
+    "road": "Juhani Ahon tie",
+    "house_number": "10"
+  },
+  {
+    "uid": "87e6df6c-a8c4-477e-8409-75ce0c2ea77b",
+    "road": "Juhani Ahon tie",
+    "house_number": "4"
+  },
+  {
+    "uid": "d5a0462a-8115-4aba-b505-81aa8cb86d1e",
+    "road": "Juhani Ahon tie",
+    "house_number": "4"
+  },
+  {
+    "uid": "a9727961-96ba-4e87-8f62-08f0b1ae8dca",
+    "road": "Rehbinderintie",
+    "house_number": "3"
+  },
+  {
+    "uid": "b469fb28-3978-48cd-88de-156943ba9232",
+    "road": "Chydeniuksentie",
+    "house_number": "2"
+  },
+  {
+    "uid": "e81f5242-ac21-48de-9e9e-586ce7ac68ab",
+    "road": "Chydeniuksentie",
+    "house_number": "1"
+  },
+  {
+    "uid": "97e59dfe-b089-4305-80ea-8819fff93419",
+    "road": "Tykistönkatu"
+  },
+  {
+    "uid": "d9878ab9-b921-45e8-b039-688ccda655d1",
+    "road": "Tykistönkatu"
+  },
+  {
+    "uid": "a77aa5c6-babc-4fe1-9626-79f86595343a",
+    "road": "Juhani Ahon tie",
+    "house_number": "2"
+  },
+  {
+    "uid": "6498f7a3-9fb6-49b4-a4f5-95635586a55e",
+    "road": "Tykistönkatu"
+  },
+  {
+    "uid": "8f43b946-eb75-40fd-82b0-1efaa37aef1d",
+    "road": "Juhani Ahon tie"
+  },
+  {
+    "uid": "a556cbf2-b83e-4d33-af4a-bf3d36daea42",
+    "road": "Armfeltintie",
+    "house_number": "1"
+  },
+  {
+    "uid": "a94dccc2-4963-4e42-a42f-7e2c45522046",
+    "road": "Runeberginkatu"
+  },
+  {
+    "uid": "607018f1-2295-45a2-aae8-6e584d59bed1",
+    "road": "Ehrensvärdintie",
+    "house_number": "1"
+  },
+  {
+    "uid": "ec5fe801-cdc1-484a-9046-a2c71a99c35a",
+    "road": "Töölönkatu"
+  },
+  {
+    "uid": "959d0f5f-ee86-4aba-9611-0d59f21c8bc1",
+    "road": "Ehrensvärdintie",
+    "house_number": "17"
+  },
+  {
+    "uid": "67d15e67-c2d0-436b-80be-2e08664e375e",
+    "road": "Runeberginkatu",
+    "house_number": "61"
+  },
+  {
+    "uid": "d16cc3cd-66a8-4edf-9005-8858cd3c1429",
+    "road": "Runeberginkatu"
+  },
+  {
+    "uid": "d9437532-8b7d-43a7-bd09-dafe3f10fd95",
+    "road": "Runeberginkatu"
+  },
+  {
+    "uid": "66517e69-77ea-4b99-84f5-bbe60bf25f1f",
+    "road": "Ehrensvärdintie",
+    "house_number": "27"
+  },
+  {
+    "uid": "d018bbdf-aec5-4222-9743-bfa8af804c20",
+    "road": "Runeberginkatu",
+    "house_number": "60"
+  },
+  {
+    "uid": "0249b20b-fbbf-4020-961e-ebabd53e1579",
+    "road": "Runeberginkatu",
+    "house_number": "60"
+  },
+  {
+    "uid": "164b83b5-485c-4ef4-b836-49fb587e9f9d",
+    "road": "Runeberginkatu",
+    "house_number": "58"
+  },
+  {
+    "uid": "d55bcd4f-ed26-4bf1-b158-e8c0b4ab4d72",
+    "road": "Wecksellintie"
+  },
+  {
+    "uid": "a62b012b-bb13-466b-9fef-b47479a086c4",
+    "road": "Dunckerinkatu"
+  },
+  {
+    "uid": "e08ab3b6-506b-498a-9f45-f90a20541abd",
+    "road": "Merikatu"
+  },
+  {
+    "uid": "aee92d2f-1916-4bff-bda0-2a6aeac47847",
+    "road": "Dunckerinkatu"
+  },
+  {
+    "uid": "e19e6ffa-1adf-4073-9fc4-3f0d945adf32",
+    "road": "Merikatu"
+  },
+  {
+    "uid": "af0d7cdd-b3c6-4e04-94d0-cde836d6f32f",
+    "road": "Dunckerinkatu",
+    "house_number": "2"
+  },
+  {
+    "uid": "ae5972e7-5450-4064-83d1-4d94694f2e67",
+    "road": "Merikatu"
+  },
+  {
+    "uid": "1cd9f07f-2bbb-4375-9195-bf2eff6d18cc",
+    "road": "Dunckerinkatu"
+  },
+  {
+    "uid": "b379ca26-bfcb-4237-b83d-086abf382e9b",
+    "road": "Merikatu"
+  },
+  {
+    "uid": "62bf65e2-03ba-4e85-abf8-655d5915cd16",
+    "road": "Dunckerinkatu"
+  },
+  {
+    "uid": "4a5d3265-b50a-432d-b596-df1df1a5a2a1",
+    "road": "Pohjoinen Hesperiankatu"
+  },
+  {
+    "uid": "04ac34a8-5537-4b7e-b84b-a4adb4b079f9",
+    "road": "Paavo Nurmen kuja"
+  },
+  {
+    "uid": "bd63ec59-268b-4ca1-b0af-150ad2438eaa",
+    "road": "Eiranranta"
+  },
+  {
+    "uid": "d1c7fad2-63dd-4562-a970-4aa0a5ccd4ba",
+    "road": "Döbelninkatu",
+    "house_number": "2"
+  },
+  {
+    "uid": "4a1a046b-31c0-4208-9e0c-bc126478d1eb",
+    "road": "Armfeltintie"
+  },
+  {
+    "uid": "f43a3c62-89bb-42e3-9e5e-ab1a78b11ff6",
+    "road": "Töölöntorinkatu",
+    "house_number": "5"
+  },
+  {
+    "uid": "aaf0951d-ddec-4083-8bdc-4cf047e57f14",
+    "road": "Merikatu",
+    "house_number": "31"
+  },
+  {
+    "uid": "fe35eff9-2686-41f7-854c-c9c49fc62d50",
+    "road": "Töölöntorinkatu",
+    "house_number": "6"
+  },
+  {
+    "uid": "4d1c6b47-aa0f-46b8-931e-6682e5901cab",
+    "road": "Töölöntorinkatu",
+    "house_number": "6"
+  },
+  {
+    "uid": "7c1258a5-8095-4018-984b-6103c2df9405",
+    "road": "Merikatu",
+    "house_number": "43-45"
+  },
+  {
+    "uid": "5fc694cb-a2d1-4c23-9fc1-36cee6f024c0",
+    "road": "Töölöntorinkatu"
+  },
+  {
+    "uid": "ec2a60ef-5a7b-4751-8863-57417cafe9df",
+    "road": "Töölöntorinkatu"
+  },
+  {
+    "uid": "93a13015-0b37-4c69-96fd-d4a76c709024",
+    "road": "Sibeliuksenkatu"
+  },
+  {
+    "uid": "ce47aa58-3e2d-4bef-92bd-593dab244b15"
+  },
+  {
+    "uid": "8850830e-9709-447a-8f47-aef7446c688c",
+    "road": "Töölöntori"
+  },
+  {
+    "uid": "71a29415-bf47-4206-aa23-c9b3de0de323",
+    "road": "Merisatamanranta"
+  },
+  {
+    "uid": "a146bc01-8efd-4bd5-9a38-bbcd336b7a25",
+    "road": "Merisatamanranta"
+  },
+  {
+    "uid": "1a86ab5d-8dd7-4f58-b6ad-7957af6da777",
+    "road": "Merisatamanranta"
+  },
+  {
+    "uid": "45bdbaa6-3769-41a2-a28f-3c5f8b9de5ce",
+    "road": "Töölönkatu",
+    "house_number": "17"
+  },
+  {
+    "uid": "96b8be1e-c542-4d60-ab15-20a0d0554a44",
+    "road": "Töölönkatu",
+    "house_number": "26"
+  },
+  {
+    "uid": "aebf4ad4-4b95-40ff-8b18-8eba8bb86acb",
+    "road": "Eiranranta"
+  },
+  {
+    "uid": "576c5bb4-6356-45cb-9bec-10734ded3404",
+    "road": "Eiranranta"
+  },
+  {
+    "uid": "982111a0-9dbf-403f-a12e-903a17d0b618",
+    "road": "Töölönkatu",
+    "house_number": "21"
+  },
+  {
+    "uid": "a3804891-e9a5-409a-819a-23db6534a88e",
+    "road": "Töölönkatu",
+    "house_number": "30b"
+  },
+  {
+    "uid": "232a2e33-0c38-4229-a24c-d1f3df765948",
+    "road": "Töölönkatu",
+    "house_number": "23"
+  },
+  {
+    "uid": "0fdc677f-c9a4-4ae1-8016-3b81b8dee8d8",
+    "road": "Töölönkatu"
+  },
+  {
+    "uid": "6153d66a-2ea9-465b-aadf-e93950c91fc7",
+    "road": "Töölönkatu",
+    "house_number": "27"
+  },
+  {
+    "uid": "e013d351-82fd-4214-818d-eed60ee1fa41",
+    "road": "Töölönkatu"
+  },
+  {
+    "uid": "d51422ec-65b5-4aee-8b93-b4bfea00b228",
+    "road": "Kivelänkatu",
+    "house_number": "5-7"
+  },
+  {
+    "uid": "60a41577-e433-42ac-8f4a-0d7b82171b16",
+    "road": "Helsinginkatu",
+    "house_number": "58"
+  },
+  {
+    "uid": "6138410b-b045-4682-90b1-e418e74019c6",
+    "road": "Sibeliuksenkatu",
+    "house_number": "7"
+  },
+  {
+    "uid": "d31df651-5991-42ad-ac38-ac5f312ad218",
+    "road": "Mäntymäentie"
+  },
+  {
+    "uid": "d7fc145e-22a6-41aa-a2ba-aa1a0dd0fceb",
+    "road": "Telakkakatu"
+  },
+  {
+    "uid": "17195b06-bde1-487e-aade-3a3b3d99dc05",
+    "road": "Mäntymäentie",
+    "house_number": "2"
+  },
+  {
+    "uid": "4f212ca7-1891-417b-b72a-204c52bb356b",
+    "road": "Mäntymäentie"
+  },
+  {
+    "uid": "c328de4c-ca29-41bb-85f4-c99a8b9b3034",
+    "road": "Paavo Nurmen tie"
+  },
+  {
+    "uid": "6797254c-25bc-4711-be57-18e36af09891",
+    "road": "Paavo Nurmen tie"
+  },
+  {
+    "uid": "e504a730-d645-4f5b-80f0-e35497f576c2",
+    "road": "Paavo Nurmen tie"
+  },
+  {
+    "uid": "6f8c7130-cc4d-492f-92f4-b4d1544c1c08",
+    "road": "Paavo Nurmen tie"
+  },
+  {
+    "uid": "2591aeff-b67f-46bd-83ab-e1dae16d6c14",
+    "road": "Paavo Nurmen tie"
+  },
+  {
+    "uid": "058f005a-7571-4806-92fa-30f4d33d1109",
+    "road": "Mäntymäentie"
+  },
+  {
+    "uid": "5c9077f1-44d6-4492-8482-030afae587a2",
+    "road": "Mäntymäentie"
+  },
+  {
+    "uid": "2ede2ad8-2b0c-4de4-a05b-19990661894f",
+    "road": "Mäntymäentie"
+  },
+  {
+    "uid": "3d6aff4e-7d2c-422f-99a8-7ab16551e953",
+    "road": "Paavo Nurmen kuja"
+  },
+  {
+    "uid": "0bc77088-ca05-4e03-9675-b23fc922953c",
+    "road": "Paavo Nurmen kuja"
+  },
+  {
+    "uid": "6433c5fa-7a37-41ad-b4fc-c3ff5feff131",
+    "road": "Paavo Nurmen kuja"
+  },
+  {
+    "uid": "687a2274-ba3f-4590-95fb-5bfb742a548c",
+    "road": "Mäntymäentie"
+  },
+  {
+    "uid": "6c2e02d4-f41c-4d43-89fe-822bebdf483e",
+    "road": "Toivonkatu"
+  },
+  {
+    "uid": "03573a6f-6234-46a2-a417-ca4d178a80d1",
+    "road": "Topeliuksenkatu",
+    "house_number": "3b"
+  },
+  {
+    "uid": "369b2cdf-9fa7-4ae6-8120-89a2d24f6d49",
+    "road": "Topeliuksenkatu"
+  },
+  {
+    "uid": "5b72e0e4-a09a-4613-ba81-a07925a1bfba",
+    "road": "Töölönkatu"
+  },
+  {
+    "uid": "ba792a38-9083-4099-add3-dc1db60cbf9b",
+    "road": "Topeliuksenkatu"
+  },
+  {
+    "uid": "6921c414-03ba-4e2c-92ec-64cddc219ee6",
+    "road": "Töölönkatu"
+  },
+  {
+    "uid": "22112bac-1069-4ddf-b62f-dc656d9497dd",
+    "road": "Töölönkatu"
+  },
+  {
+    "uid": "8379b434-6a11-4920-b757-9f5ec2dc6759",
+    "road": "Sibeliuksenkatu",
+    "house_number": "10"
+  },
+  {
+    "uid": "88d52539-31bc-4a12-a4b7-0ed55b4fb104",
+    "road": "Sibeliuksenkatu",
+    "house_number": "6"
+  },
+  {
+    "uid": "ef1ab66f-1d55-45ef-b825-e28557e0b867",
+    "road": "Sibeliuksenkatu",
+    "house_number": "1"
+  },
+  {
+    "uid": "037f3cac-159d-407c-835b-1bef95350a5d",
+    "road": "Sibeliuksenkatu",
+    "house_number": "1"
+  },
+  {
+    "uid": "6ec9858c-ab00-459a-aaec-5e36802efe8d",
+    "road": "Ruusulankatu",
+    "house_number": "1"
+  },
+  {
+    "uid": "560e11a0-14c1-4e54-8da4-ea42095bcc46",
+    "road": "Sibeliuksenkatu",
+    "house_number": "6"
+  },
+  {
+    "uid": "e71940a2-41eb-487f-82ee-813733fa90d1",
+    "road": "Töölönkatu"
+  },
+  {
+    "uid": "9458ccd1-04b8-4409-ba45-f5bbd2d275af",
+    "road": "Töölönkatu",
+    "house_number": "35"
+  },
+  {
+    "uid": "9eb6d143-9660-4a10-9b77-33fc013d526c",
+    "road": "Töölönkatu"
+  },
+  {
+    "uid": "2f1fa2b7-7ee1-437f-925f-3512203d5672",
+    "road": "Töölönkatu"
+  },
+  {
+    "uid": "c1c331b5-d06c-4842-9409-931ec03127f0",
+    "road": "Töölönkatu"
+  },
+  {
+    "uid": "23964d97-4979-4e4d-97df-9a0b15083bbb",
+    "road": "Töölönkatu"
+  },
+  {
+    "uid": "e097264a-8920-4c4d-afda-2583613e17de",
+    "road": "Töölönkatu"
+  },
+  {
+    "uid": "1dd925bd-9aaa-400e-aacd-ee5cd4a9b0e0",
+    "road": "Töölönkatu",
+    "house_number": "37"
+  },
+  {
+    "uid": "561fad26-b495-4bd8-9709-a4f72128ef14",
+    "road": "Töölönkatu",
+    "house_number": "37"
+  },
+  {
+    "uid": "724843b1-d90e-4966-997c-e7b2c7a5fad5",
+    "road": "Töölönkatu",
+    "house_number": "37"
+  },
+  {
+    "uid": "c4c1eacd-c6ae-440e-bcf5-44d3f411670b",
+    "road": "Mechelininkatu",
+    "house_number": "8"
+  },
+  {
+    "uid": "d6c7911b-336c-4456-a125-d7c3f787f002",
+    "road": "Mechelininkatu"
+  },
+  {
+    "uid": "85f9bef0-1b0b-46c4-9e95-cf697b84ade6",
+    "road": "Mechelininkatu"
+  },
+  {
+    "uid": "f072a51d-539c-4bb5-82a7-b3dfbc5a70dc",
+    "road": "Mechelininkatu"
+  },
+  {
+    "uid": "ead27d19-d300-40bf-8954-31ecd0e5f791",
+    "road": "Mechelininkatu"
+  },
+  {
+    "uid": "034b7cce-7f51-4959-8ec0-7392b47ccdf5",
+    "road": "Mechelininkatu",
+    "house_number": "28b"
+  },
+  {
+    "uid": "8206e1fe-ff48-4d0d-98fc-8f781969977e",
+    "road": "Hietaniemenkatu"
+  },
+  {
+    "uid": "cbd71cd7-da1c-473a-8067-067b58225856",
+    "road": "Pohjoinen Rautatiekatu"
+  },
+  {
+    "uid": "d43bf91e-de6d-4f25-aa97-c875ac7f67e2",
+    "road": "Leppäsuonkatu",
+    "house_number": "9"
+  },
+  {
+    "uid": "7655e7b2-b974-4463-9c89-c6f6ec3548b6",
+    "road": "Hietaniemenkatu"
+  },
+  {
+    "uid": "0280e11d-07a2-4905-8236-ad5c56475124",
+    "road": "Hietaniemenkatu",
+    "house_number": "6"
+  },
+  {
+    "uid": "bcde73f1-f3d9-4bd9-8709-159221728cca",
+    "road": "Hietaniemenkatu"
+  },
+  {
+    "uid": "1cd60b61-206d-4703-b6c6-6035b517c5b1",
+    "road": "Hietaniemenkatu"
+  },
+  {
+    "uid": "3accde18-b656-458d-b12e-df8baa42c1e4",
+    "road": "Sammonkatu",
+    "house_number": "13"
+  },
+  {
+    "uid": "9931d05a-e25b-4e2c-aff8-e7d528e807a1",
+    "road": "Hietaniemenkatu",
+    "house_number": "4"
+  },
+  {
+    "uid": "0b55bb0c-bd05-4f8f-b9ce-3f950f635889",
+    "road": "Perhonkatu",
+    "house_number": "2"
+  },
+  {
+    "uid": "cb5ad4d8-7890-4b07-b40e-ec6671adfbe1",
+    "road": "Perhonkatu",
+    "house_number": "5"
+  },
+  {
+    "uid": "c83cbd6b-432b-405a-b048-c6f4220f9b3f",
+    "road": "Perhonkatu",
+    "house_number": "7"
+  },
+  {
+    "uid": "cce1d5f2-0f8c-45da-a929-72746e1ee18f",
+    "road": "Lapuankatu"
+  },
+  {
+    "uid": "743b0bde-b61c-4b35-b06f-aa0a8bbc49d3",
+    "road": "Hietaniemenkatu",
+    "house_number": "9"
+  },
+  {
+    "uid": "09ffe123-9ca7-4934-baf5-428483252788",
+    "road": "Hietaniemenkatu"
+  },
+  {
+    "uid": "96f50ee7-1356-4c05-a8c2-c22ee4ab57cf",
+    "road": "Hietaniemenkatu"
+  },
+  {
+    "uid": "faa8dcd6-1738-4e61-b991-ded1863cf882",
+    "road": "Hietaniemenkatu"
+  },
+  {
+    "uid": "9525d5ad-4425-4fa2-8aea-7a99ca60082c",
+    "road": "Hietaniemenkatu"
+  },
+  {
+    "uid": "5fa07d60-186c-4c7d-9c75-77b53131f1bf",
+    "road": "Hietaniemenkatu",
+    "house_number": "14"
+  },
+  {
+    "uid": "12ea7b72-4e1f-4f02-9995-a8bbcef1afcd",
+    "road": "Hietaniemenkatu"
+  },
+  {
+    "uid": "c7f42a7c-5a83-474f-8224-14f6f66e7594",
+    "road": "Hietaniemenkatu"
+  },
+  {
+    "uid": "ff55fb15-c7c1-479d-a854-b15f1864642e",
+    "road": "Lapuankatu"
+  },
+  {
+    "uid": "2e5ce589-b0e1-487b-8f2f-3ab60d4c81e8",
+    "road": "Hietaniemenkatu"
+  },
+  {
+    "uid": "e60a319e-3016-404c-94bc-7db626f4f7c5",
+    "road": "Lapuankatu"
+  },
+  {
+    "uid": "2ba326d5-cc79-4b0a-9fcb-656f94aa29ae",
+    "road": "Lapuankatu"
+  },
+  {
+    "uid": "3ed7fa66-5b90-4150-914a-183f8b3bbdc6",
+    "road": "Lapuankatu"
+  },
+  {
+    "uid": "0a2a4cd2-ce92-44a3-8e69-459a24d166db",
+    "road": "Lapuankatu"
+  },
+  {
+    "uid": "b0548608-3b7e-4e1c-a947-6747c1dd1126",
+    "road": "Lapuankatu"
+  },
+  {
+    "uid": "4faeac40-84f3-4d1f-84b9-2b9c836b5c9b",
+    "road": "Krematoriontie"
+  },
+  {
+    "uid": "0d086ba1-419f-4412-9838-055244d2f8b4",
+    "road": "Arkadiankatu"
+  },
+  {
+    "uid": "3b4ce06d-4952-41ad-9b9f-1db183614334",
+    "road": "Krematoriontie"
+  },
+  {
+    "uid": "f46d731d-f82f-400e-a4f8-222921146c52",
+    "road": "Arkadiankatu",
+    "house_number": "24"
+  },
+  {
+    "uid": "d8f3c908-810a-4742-819f-a0986c0d10e4",
+    "road": "Arkadiankatu"
+  },
+  {
+    "uid": "9a4b0715-a1e0-4eb4-92a8-ebe0f958a69e",
+    "road": "Arkadiankatu"
+  },
+  {
+    "uid": "f5745b4f-a0b4-4d28-b5cd-af8709689570",
+    "road": "Arkadiankatu"
+  },
+  {
+    "uid": "b2b7ee0e-8946-47ac-aeac-d1300f0ef56f",
+    "road": "Tunturikatu",
+    "house_number": "6"
+  },
+  {
+    "uid": "ee2ea43e-19f3-4214-89d9-084fe65afea6",
+    "road": "Arkadiankatu",
+    "house_number": "35"
+  },
+  {
+    "uid": "142a1c27-7771-412d-a84d-73348f253ce0",
+    "road": "Arkadiankatu",
+    "house_number": "24"
+  },
+  {
+    "uid": "26e0b7ce-42ab-418a-aba4-d830e7f11edb",
+    "road": "Arkadiankatu",
+    "house_number": "31"
+  },
+  {
+    "uid": "84766869-d51d-4397-ab2d-4e64f23cbc3e",
+    "road": "Runeberginkatu",
+    "house_number": "17"
+  },
+  {
+    "uid": "b6d4ea03-c9a4-474c-a361-e75c2674e55f",
+    "road": "Runeberginkatu",
+    "house_number": "8"
+  },
+  {
+    "uid": "15bf1a58-ff11-40d6-a70d-f95b67c1b4fe",
+    "road": "Arkadiankatu",
+    "house_number": "14"
+  },
+  {
+    "uid": "18644b5a-78a1-41a1-b280-55ff55a060b6",
+    "road": "Arkadiankatu"
+  },
+  {
+    "uid": "ad20a8f2-19f4-4574-b9cb-3af3205d5b54",
+    "road": "Arkadiankatu",
+    "house_number": "37"
+  },
+  {
+    "uid": "084beb5c-c425-4523-8ed8-3278d287a264",
+    "road": "Arkadiankatu",
+    "house_number": "12"
+  },
+  {
+    "uid": "688ae19e-f0b7-4981-8485-ce4bdd758622",
+    "road": "Väinämöisenkatu",
+    "house_number": "1"
+  },
+  {
+    "uid": "7a742e36-ba0e-4c81-9d42-9c2d687d45ff",
+    "road": "Väinämöisenkatu"
+  },
+  {
+    "uid": "19c35a8b-4018-44b6-a1ed-1b20f763658c",
+    "road": "Väinämöisenkatu"
+  },
+  {
+    "uid": "8fd42ec8-9577-424c-aba2-881ac8d21a5b",
+    "road": "Sammonkatu"
+  },
+  {
+    "uid": "b98663d7-ab73-4184-be0d-de2a82bbe5d4",
+    "road": "Arkadiankatu",
+    "house_number": "8"
+  },
+  {
+    "uid": "1817dfae-a2e9-47ab-b159-c0d72fb0afc6",
+    "road": "Fredrikinkatu",
+    "house_number": "67"
+  },
+  {
+    "uid": "caaf8b5f-6d4f-4b26-8bd8-fedcd14aa380",
+    "road": "Fredrikinkatu",
+    "house_number": "69"
+  },
+  {
+    "uid": "7c7a1ab8-d5b5-45c1-91b1-4fb0b47c9f47",
+    "road": "Fredrikinkatu",
+    "house_number": "69"
+  },
+  {
+    "uid": "1cc9785a-87ce-41fa-88d0-c3ccd139e8bf",
+    "road": "Fredrikinkatu",
+    "house_number": "60"
+  },
+  {
+    "uid": "876fa738-7c14-4952-81b5-1876127a7b54",
+    "road": "Fredrikinkatu",
+    "house_number": "56"
+  },
+  {
+    "uid": "c3f1730a-ba91-4b05-bfa3-196c2a55cde4",
+    "road": "Fredrikinkatu",
+    "house_number": "56"
+  },
+  {
+    "uid": "c4563cc3-2185-42cf-835b-a35e572f480d",
+    "road": "Väinämöisenkatu"
+  },
+  {
+    "uid": "0cc60bcd-0152-461f-abf1-b3106296a3d0",
+    "road": "Väinämöisenkatu",
+    "house_number": "27"
+  },
+  {
+    "uid": "cf7870de-f855-4a9a-9111-4614e441a31e",
+    "road": "Väinämöisenkatu"
+  },
+  {
+    "uid": "95aa65a0-4b6e-4f8e-99d2-3054949f8b85",
+    "road": "Lutherinkatu"
+  },
+  {
+    "uid": "48788d1b-a195-44cc-8888-57ee88a08128",
+    "road": "Väinämöisenkatu"
+  },
+  {
+    "uid": "670d6a93-1529-4c51-9f4b-8d1b22a85629",
+    "road": "Lutherinkatu"
+  },
+  {
+    "uid": "9b2aa652-cf81-44dc-b187-2f565e157a79",
+    "road": "Väinämöisenkatu",
+    "house_number": "29"
+  },
+  {
+    "uid": "c9964e3e-de2e-43b0-918f-974f4be3c157",
+    "road": "Ilmarinkatu",
+    "house_number": "4a"
+  },
+  {
+    "uid": "41c197c1-d1ac-419d-80f6-70d41af53787",
+    "road": "Väinämöisenkatu",
+    "house_number": "23"
+  },
+  {
+    "uid": "18394613-27ff-4247-add1-c57ac1cb655f",
+    "road": "Lemminkäisenkuja"
+  },
+  {
+    "uid": "ee749757-3abd-4266-b2af-9a3de1f195c0",
+    "road": "Arkadiankatu"
+  },
+  {
+    "uid": "086ed4a9-cb7e-4554-83fb-2ca8ebb37751",
+    "road": "Lemminkäisenkuja"
+  },
+  {
+    "uid": "7574f3fd-0bcd-4dcd-913c-10203ef84647",
+    "road": "Ilmarinkatu",
+    "house_number": "4a"
+  },
+  {
+    "uid": "83d121d6-a46f-4c9f-a621-4d721c522f53",
+    "road": "Ilmarinkatu"
+  },
+  {
+    "uid": "735aa9f4-607b-4578-8ab9-f38c5de7c458",
+    "road": "Sammonkatu"
+  },
+  {
+    "uid": "e4300f42-f1fe-413f-b3a8-f62dd6582395",
+    "road": "Tuonelankuja"
+  },
+  {
+    "uid": "acde6b70-fca9-41d3-b87c-1907fd34bd98",
+    "road": "Sammonkatu"
+  },
+  {
+    "uid": "88044e5c-b1c8-4c67-86eb-ecacd77f5c64",
+    "road": "Sammonkatu"
+  },
+  {
+    "uid": "75798e5a-e408-4d0d-be7f-2a6edf456b66",
+    "road": "Sammonkatu"
+  },
+  {
+    "uid": "db3c1536-d553-4fbf-bc98-6600f4ee4838",
+    "road": "Hiekkarannantie"
+  },
+  {
+    "uid": "82401d02-ed87-4415-92fd-69dfcba01c83",
+    "road": "Ilmarinkatu"
+  },
+  {
+    "uid": "7247d39a-0ec2-433e-899a-2602b481f0b5",
+    "road": "Ilmarinkatu"
+  },
+  {
+    "uid": "b5f262bf-b2be-47f1-a390-043b02c6e459",
+    "road": "Ilmarinkatu",
+    "house_number": "10"
+  },
+  {
+    "uid": "43aabfd3-d810-4a00-9f87-86d920d3f370",
+    "road": "Eteläinen Hesperiankatu"
+  },
+  {
+    "uid": "0793aa9e-024b-4d41-b6bc-80b0697dbadc",
+    "road": "Hietaniemenkatu",
+    "house_number": "20"
+  },
+  {
+    "uid": "7119b8c5-cd0f-4952-bc81-c519b3093cac",
+    "road": "Eteläinen Hesperiankatu"
+  },
+  {
+    "uid": "ecabc717-8c7f-41a9-9a3c-1bf1c697a265",
+    "road": "Tunturikatu",
+    "house_number": "6"
+  },
+  {
+    "uid": "2eae0602-774c-445b-9940-edb70537721b",
+    "road": "Museokatu",
+    "house_number": "29"
+  },
+  {
+    "uid": "44afcca7-cea0-4a2a-a96e-c3c6c865cb33",
+    "road": "Museokatu",
+    "house_number": "35"
+  },
+  {
+    "uid": "43e07e44-ac54-4db0-84fc-25220cefdb3f",
+    "road": "Museokatu",
+    "house_number": "37"
+  },
+  {
+    "uid": "312f6551-8632-40ea-b5e4-9689573322ba",
+    "road": "Tunturikatu",
+    "house_number": "18"
+  },
+  {
+    "uid": "44fcaeb9-c9f6-45cc-8ff9-3fce6b4dd498",
+    "road": "Museokatu",
+    "house_number": "46"
+  },
+  {
+    "uid": "c55546e5-8ae4-43cd-bb98-f7d0d5a0d328",
+    "road": "Museokatu",
+    "house_number": "31"
+  },
+  {
+    "uid": "93437f79-5d72-4715-aaee-3638974d30cb",
+    "road": "Tunturikatu"
+  },
+  {
+    "uid": "0a994661-10f9-4175-bae9-df979e74c689",
+    "road": "Oksasenkatu",
+    "house_number": "2"
+  },
+  {
+    "uid": "ec7e5f5c-e715-4342-aa9b-7761b0c54bc9",
+    "road": "Tunturikatu",
+    "house_number": "14"
+  },
+  {
+    "uid": "ca825e16-d633-4917-a6a1-190ec30a1479",
+    "road": "Tunturikatu",
+    "house_number": "4"
+  },
+  {
+    "uid": "3cd04782-bcbc-45bd-a46c-1a8050c40007",
+    "road": "Tunturikatu"
+  },
+  {
+    "uid": "65ab741f-2f7e-4c38-8ba0-536d5b691f94",
+    "road": "Caloniuksenkatu",
+    "house_number": "1"
+  },
+  {
+    "uid": "2466d10f-4129-461d-a0bd-15a0e67f50c0",
+    "road": "Tunturikatu",
+    "house_number": "8"
+  },
+  {
+    "uid": "6ab7129f-d9ca-406b-b1b9-9d97a2052908",
+    "road": "Caloniuksenkatu"
+  },
+  {
+    "uid": "e28cde95-cd90-41b9-9f5e-84b73d37098b",
+    "road": "Oksasenkatu"
+  },
+  {
+    "uid": "e6f19e04-3449-49f1-a540-bf2583f30f18",
+    "road": "Fredrikinkatu"
+  },
+  {
+    "uid": "612895c3-6034-44ac-9bd3-72c06d5db7f8",
+    "road": "Fredrikinkatu",
+    "house_number": "66"
+  },
+  {
+    "uid": "21901e4b-f33e-4c6c-ab6b-7e58ad1e4895",
+    "road": "Fredrikinkatu",
+    "house_number": "64"
+  },
+  {
+    "uid": "8aa95b01-aec9-4a97-8d88-931bc67e220f",
+    "road": "Eteläinen Hesperiankatu",
+    "house_number": "22"
+  },
+  {
+    "uid": "d3862f3b-f891-4261-ace8-1753b524d63c",
+    "road": "Sammonkatu"
+  },
+  {
+    "uid": "1b481989-7e56-4984-b6b9-7f2f81412e4a",
+    "road": "Sammonkatu",
+    "house_number": "2"
+  },
+  {
+    "uid": "ea8fab26-4e4c-48fa-8b14-2f339ad24ad4",
+    "road": "Temppelikatu"
+  },
+  {
+    "uid": "2e6808fc-f2ee-43c1-a590-68271c7f3fb6",
+    "road": "Temppelikatu"
+  },
+  {
+    "uid": "fe8d7c8d-9c95-44c9-9eca-a11530957d3c",
+    "road": "Eteläinen Hesperiankatu"
+  },
+  {
+    "uid": "34d28dac-fb8f-4fbd-8080-70061cb04465",
+    "road": "Töölönkatu"
+  },
+  {
+    "uid": "03d236da-893a-4d04-b654-f18b66225e1b",
+    "road": "Pohjoinen Hesperiankatu"
+  },
+  {
+    "uid": "dc1e2877-56b6-49d5-ac89-a76f0b2172a7",
+    "road": "Eteläinen Hesperiankatu"
+  },
+  {
+    "uid": "e8354293-625d-446e-bed7-c0d60a875b35",
+    "road": "Fredrikinkatu",
+    "house_number": "79"
+  },
+  {
+    "uid": "915c1b90-939a-4e02-a1cb-d529861274d0",
+    "road": "Fredrikinkatu",
+    "house_number": "70"
+  },
+  {
+    "uid": "4123a051-c805-44e9-974c-73443bf17bda",
+    "road": "Fredrikinkatu",
+    "house_number": "64"
+  },
+  {
+    "uid": "b6459933-c50c-4933-a259-844d3363f58d",
+    "road": "Dagmarinkatu",
+    "house_number": "9"
+  },
+  {
+    "uid": "4f5aad8f-8862-46d2-9b35-fe69b1b04416",
+    "road": "Dagmarinkatu",
+    "house_number": "9"
+  },
+  {
+    "uid": "200d4046-4208-4409-a30d-1f55e864349d",
+    "road": "Dagmarinkatu",
+    "house_number": "13"
+  },
+  {
+    "uid": "cd58248f-c8f4-4249-91ed-2bfdb5c81885",
+    "road": "Dagmarinkatu"
+  },
+  {
+    "uid": "fecec6df-db40-4316-8fce-38df0e834b07",
+    "road": "Dagmarinkatu",
+    "house_number": "12"
+  },
+  {
+    "uid": "bb11fd49-4283-44f3-95b0-30211860564e",
+    "road": "Arkadiankatu"
+  },
+  {
+    "uid": "cc8c50f8-938c-45b8-ae68-710106c092de",
+    "road": "Aurorankatu",
+    "house_number": "17"
+  },
+  {
+    "uid": "07695645-ec08-4575-aa26-d5bee13aa897",
+    "road": "Freesenkatu",
+    "house_number": "1"
+  },
+  {
+    "uid": "2bb7ea21-4e30-4808-99dd-e5475d4fcf50",
+    "road": "Freesenkatu"
+  },
+  {
+    "uid": "8a50955e-7bcd-43c0-802f-9a085e6f3fa7",
+    "road": "Aurorankatu",
+    "house_number": "13"
+  },
+  {
+    "uid": "b22c6b2b-fac0-4221-94bd-2ffdc98e69b6",
+    "road": "Nervanderinkatu"
+  },
+  {
+    "uid": "2f9a96c9-f3bc-4405-9671-30dcc377aff4",
+    "road": "Ainonkatu"
+  },
+  {
+    "uid": "e7d45a23-ca34-4ea0-aa5b-1d96a1a2cae2",
+    "road": "Ainonkatu",
+    "house_number": "3"
+  },
+  {
+    "uid": "78358abf-5de5-4ddc-89e8-a5be9895078f",
+    "road": "Ainonkatu",
+    "house_number": "3"
+  },
+  {
+    "uid": "b2cb2bd0-0065-4ce8-8664-a19cd1d94143",
+    "road": "Ainonkatu"
+  },
+  {
+    "uid": "83630f4d-2535-4bb1-bf5b-3a997a2a9617",
+    "road": "Nervanderinkatu"
+  },
+  {
+    "uid": "b6dac942-cba0-4dce-a1a4-8d446474f51d",
+    "road": "Runeberginkatu",
+    "house_number": "25"
+  },
+  {
+    "uid": "2b7c850a-44bb-457e-a55c-0b0d699f4397",
+    "road": "Lutherinkatu",
+    "house_number": "14"
+  },
+  {
+    "uid": "68ed5dff-32a8-4eaf-bd03-7a8c32e91ffd",
+    "road": "Lutherinkatu",
+    "house_number": "12"
+  },
+  {
+    "uid": "4a210f70-9cf4-4ed2-af92-42d4914d9b88",
+    "road": "Lutherinkatu",
+    "house_number": "16"
+  },
+  {
+    "uid": "72fc09e7-ea0f-4d95-9346-998a4a4eeb11",
+    "road": "Lutherinkatu"
+  },
+  {
+    "uid": "ce21fafc-1fb3-4424-9bc4-f5f8db334f07",
+    "road": "Temppelikatu"
+  },
+  {
+    "uid": "d7bb44f8-ade8-41fb-a8f2-5da7b3efb34b",
+    "road": "Temppelikatu"
+  },
+  {
+    "uid": "7a88307d-2497-409d-b374-5c0d840781e5",
+    "road": "Temppelikatu"
+  },
+  {
+    "uid": "d2685fff-315e-46db-8e90-3d73ed8934de",
+    "road": "Temppelikatu",
+    "house_number": "14"
+  },
+  {
+    "uid": "4a0187b1-7d7f-4c2c-98be-86ca8c2017ad",
+    "road": "Temppelikatu"
+  },
+  {
+    "uid": "6a1fc410-cc06-419a-b391-e6a1bf13b4e0",
+    "road": "Temppelikatu"
+  },
+  {
+    "uid": "88db5def-92f7-49ec-a1b3-10cdbe5d352b",
+    "road": "Temppelikatu",
+    "house_number": "6"
+  },
+  {
+    "uid": "5cd83975-37fa-42c9-a0b1-c6e74e6f43a0",
+    "road": "Temppelikatu",
+    "house_number": "1"
+  },
+  {
+    "uid": "259a36ce-2ee1-4f8f-ad17-f2b2dfae0105",
+    "road": "Temppelikatu",
+    "house_number": "1"
+  },
+  {
+    "uid": "02d7db96-2ea5-471b-a8f4-9b0f98ad400b",
+    "road": "Nervanderinkatu"
+  },
+  {
+    "uid": "b5944390-8e97-4b6e-9c92-6473e5122b40",
+    "road": "Nervanderinkatu",
+    "house_number": "8"
+  },
+  {
+    "uid": "ff55d5a1-9de5-4aaf-9f08-c77a68380440",
+    "road": "Nervanderinkatu"
+  },
+  {
+    "uid": "4fdec6a8-7d22-42fb-bfe2-0ee954d2757d",
+    "road": "Nervanderinkatu"
+  },
+  {
+    "uid": "d85ca9d5-b808-46db-8c85-bc8cfde83f31",
+    "road": "Nervanderinkatu"
+  },
+  {
+    "uid": "10233d7c-1dc9-44d8-8454-a4c0b239d68d",
+    "road": "Nervanderinkatu",
+    "house_number": "7"
+  },
+  {
+    "uid": "e40bb204-05c8-4d75-b738-97d9a6e4193b",
+    "road": "Nervanderinkatu"
+  },
+  {
+    "uid": "90265df7-ec3a-4ed6-acf9-6759a4e1f6e0",
+    "road": "Nervanderinkatu"
+  },
+  {
+    "uid": "4f3bb66d-73bb-4fde-bfce-25a08a4ad356",
+    "road": "Nervanderinkatu"
+  },
+  {
+    "uid": "c66b03f8-7981-4b30-99ac-a3bdc7c06c72",
+    "road": "Töölönkatu",
+    "house_number": "4"
+  },
+  {
+    "uid": "f84c63b1-c8e5-4913-be40-348c559db0f1",
+    "road": "Nervanderinkatu"
+  },
+  {
+    "uid": "0f37466b-42e5-4177-a54b-7f06408d6fb9",
+    "road": "Nervanderinkatu"
+  },
+  {
+    "uid": "9203d8d1-111d-4691-bdda-7b62d195dda6",
+    "road": "Cygnaeuksenkatu",
+    "house_number": "4"
+  },
+  {
+    "uid": "e98de683-be33-459f-a7e2-49a2585e5485",
+    "road": "Nervanderinkatu",
+    "house_number": "12"
+  },
+  {
+    "uid": "bc3946e0-7c22-4e39-8ba4-2c893468bba6",
+    "road": "Aurorankatu",
+    "house_number": "11"
+  },
+  {
+    "uid": "4ceac6ae-cb4b-4223-a8c6-579923235ec1",
+    "road": "Aurorankatu"
+  },
+  {
+    "uid": "d07f664c-f657-42df-96d4-c7339f89af4b",
+    "road": "Aurorankatu"
+  },
+  {
+    "uid": "f8764f1f-9bca-4f4e-92e9-6322e6e16ba7",
+    "road": "Aurorankatu"
+  },
+  {
+    "uid": "8909232c-fbb8-475f-8839-171abf0b9c5c",
+    "road": "Aurorankatu",
+    "house_number": "5"
+  },
+  {
+    "uid": "e984927e-36ea-4f9d-9eee-9adf83848dcf",
+    "road": "Aurorankatu"
+  },
+  {
+    "uid": "d2361aea-4d2a-4c9e-a3b6-b941687e22c9",
+    "road": "Töölönkatu"
+  },
+  {
+    "uid": "5ded584c-ae73-438a-b105-b22b045d71f9",
+    "road": "Töölönkatu",
+    "house_number": "4"
+  },
+  {
+    "uid": "f97b4d24-b619-48c5-ba75-13d89272099c",
+    "road": "Töölönkatu",
+    "house_number": "4"
+  },
+  {
+    "uid": "1df9d356-3d78-4528-849f-290215d0f034",
+    "road": "Dagmarinkatu"
+  },
+  {
+    "uid": "6c234e02-e443-4002-8343-84e551165c82",
+    "road": "Dagmarinkatu"
+  },
+  {
+    "uid": "c7164a50-86b7-4aac-af49-64f5c3b78f31",
+    "road": "Dagmarinkatu"
+  },
+  {
+    "uid": "7df11aab-b290-4733-a5ca-04f9c9ccd8cb",
+    "road": "Dagmarinkatu"
+  },
+  {
+    "uid": "e0a7c936-a937-4c42-b8a1-3c8ff3d5789f",
+    "road": "Dagmarinkatu"
+  },
+  {
+    "uid": "6a3c1747-2e29-4cca-9b9f-13f04c3d0eb8",
+    "road": "Museokatu"
+  },
+  {
+    "uid": "eed4ddfa-282f-4d18-be71-787297abf34e",
+    "road": "Museokatu",
+    "house_number": "25"
+  },
+  {
+    "uid": "6d4b7c92-d350-441e-aced-f038227f9233",
+    "road": "Museokatu",
+    "house_number": "21"
+  },
+  {
+    "uid": "cecec3ee-8854-4e46-9be0-c8550e436930",
+    "road": "Museokatu"
+  },
+  {
+    "uid": "7fe890a3-3298-4810-baba-8ea7ee20a416",
+    "road": "Museokatu"
+  },
+  {
+    "uid": "9ee0ccca-94e0-45f3-93d2-9011dac2051e",
+    "road": "Museokatu"
+  },
+  {
+    "uid": "6571ecbd-0d74-4aad-b44a-f2615bfbddde",
+    "road": "Museokatu",
+    "house_number": "30-32"
+  },
+  {
+    "uid": "69f2ca80-6a34-4cba-b009-583fbf1d29c7",
+    "road": "Museokatu"
+  },
+  {
+    "uid": "1d4ba8e6-9b79-4a16-b25f-7f9de9ce611c",
+    "road": "Museokatu"
+  },
+  {
+    "uid": "04bce383-d6b0-4113-b42b-acfdc1f86a44",
+    "road": "Museokatu"
+  },
+  {
+    "uid": "30a12ea9-ec7b-490d-9f42-c4b001627ae8",
+    "road": "Museokatu"
+  },
+  {
+    "uid": "b0257444-e2b7-432f-9284-33bad118b602",
+    "road": "Museokatu",
+    "house_number": "5"
+  },
+  {
+    "uid": "b5028a1b-eef8-40bc-a17f-74d9fe5ceb37",
+    "road": "Museokatu"
+  },
+  {
+    "uid": "df33657b-6be3-47ca-8b74-c74ce1bb7a8f",
+    "road": "Museokatu"
+  },
+  {
+    "uid": "9a3aebbd-17e1-4504-a6c1-c222d6415c78",
+    "road": "Museokatu",
+    "house_number": "10"
+  },
+  {
+    "uid": "5b176580-06be-4210-ace4-9faffc81a340",
+    "road": "Museokatu"
+  },
+  {
+    "uid": "78218689-dea9-48a1-8422-64ed65476769",
+    "road": "Museokatu",
+    "house_number": "8"
+  },
+  {
+    "uid": "2baa9c86-58aa-4b61-8a38-44ab31993be7",
+    "road": "J. R. Aspelinin aukio"
+  },
+  {
+    "uid": "0235ed41-8ed9-4031-bb79-cb1eb77565f6",
+    "road": "Oksasenkatu",
+    "house_number": "5"
+  },
+  {
+    "uid": "647bb612-f04d-407e-8828-27e3c1a12a1d",
+    "road": "Oksasenkatu",
+    "house_number": "7"
+  },
+  {
+    "uid": "7cb51bb2-0cc8-4f22-92b0-d266e1d325dc",
+    "road": "Oksasenkatu"
+  },
+  {
+    "uid": "56a517f6-2c2d-41b6-9829-b33b6b3eda38",
+    "road": "Apollonkatu",
+    "house_number": "23"
+  },
+  {
+    "uid": "e7eea60f-0b86-4681-bcf1-1815c1b9fa67",
+    "road": "Apollonkatu"
+  },
+  {
+    "uid": "0f0dea8e-ea7d-4ec1-85d8-00412fade373",
+    "road": "Minervankatu"
+  },
+  {
+    "uid": "0d263413-6d20-44a4-9c98-e3254b5fab96",
+    "road": "Minervanpolku"
+  },
+  {
+    "uid": "fa4a8001-0132-465e-bf12-18e1e3bf0851",
+    "road": "Apollonkatu",
+    "house_number": "15"
+  },
+  {
+    "uid": "2b217741-ab43-4f69-8169-5cd5ec96dc03",
+    "road": "Apollonkatu",
+    "house_number": "11b"
+  },
+  {
+    "uid": "95783c4b-1a09-47a4-b2bd-70be5114d574",
+    "road": "Minervanpolku"
+  },
+  {
+    "uid": "d0732267-98f5-4aab-963f-dbccec136d78",
+    "road": "Minervanpolku"
+  },
+  {
+    "uid": "4d47ff09-1e73-4758-a590-427181153d2c",
+    "road": "Apollonkatu"
+  },
+  {
+    "uid": "6f158438-215b-4b53-9c8a-ad5afd7c2229",
+    "road": "Apollonkatu",
+    "house_number": "5"
+  },
+  {
+    "uid": "dce3af3a-cde3-4d94-b971-c7641c4a2ae0",
+    "road": "Vänrikki Stoolin katu"
+  },
+  {
+    "uid": "4cdff3f4-9a2f-4eed-9231-449ae54e1fd2",
+    "road": "Apollonkatu"
+  },
+  {
+    "uid": "7a14963d-9de4-4fa9-954d-9824c5dfce99",
+    "road": "Vänrikki Stoolin katu",
+    "house_number": "6"
+  },
+  {
+    "uid": "bd56bc2b-e88f-47dc-b431-dd90402e42a4",
+    "road": "Apollonkatu"
+  },
+  {
+    "uid": "9af90bd2-a1a3-4f74-8275-9e9d88541e1b",
+    "road": "Eteläinen Hesperiankatu"
+  },
+  {
+    "uid": "0a8a398d-51fa-4765-94fc-4b5858aa2a79",
+    "road": "Apollonkatu",
+    "house_number": "6"
+  },
+  {
+    "uid": "181981f9-562a-42d6-a56d-a50d64101297",
+    "road": "Apollonkatu",
+    "house_number": "2"
+  },
+  {
+    "uid": "53361051-2ead-43ef-9bc4-35815177785f",
+    "road": "Cygnaeuksenkatu",
+    "house_number": "6"
+  },
+  {
+    "uid": "891fdcf3-5efe-4142-8fe2-fc151565dd63",
+    "road": "Cygnaeuksenkatu",
+    "house_number": "12"
+  },
+  {
+    "uid": "b186a824-7597-4d0f-a42a-a895f6820cc3",
+    "road": "Töölönkatu",
+    "house_number": "5"
+  },
+  {
+    "uid": "7998b265-ed4e-4614-83dc-7f7ab932c9ba",
+    "road": "Töölönkatu"
+  },
+  {
+    "uid": "2210f038-2724-4b7b-a075-aae4b6a8d763",
+    "road": "Pohjoinen Rautatiekatu"
+  },
+  {
+    "uid": "03fe04a7-0243-43c2-9661-a502084cb81c",
+    "road": "Töölönkatu"
+  },
+  {
+    "uid": "6365e817-5b40-4d66-802c-03a98d30f583",
+    "road": "Cygnaeuksenkatu",
+    "house_number": "14"
+  },
+  {
+    "uid": "d02ba04f-b4bc-4b1b-8eaa-febdcb5d0feb",
+    "road": "Cygnaeuksenkatu"
+  },
+  {
+    "uid": "c56e8884-b1dc-499a-9908-3ca93f0bfc30",
+    "road": "Töölönkatu"
+  },
+  {
+    "uid": "fe193d4e-0735-4051-8990-c511538d8d14",
+    "road": "Töölönkatu",
+    "house_number": "10"
+  },
+  {
+    "uid": "ed62d54e-3fc7-492e-ab58-c0f8208ab5bc",
+    "road": "Töölönkatu",
+    "house_number": "9"
+  },
+  {
+    "uid": "51f8a01e-9b28-4627-915a-9a76e619b0bc",
+    "road": "Töölönkatu",
+    "house_number": "16"
+  },
+  {
+    "uid": "65fbc501-843c-428c-bff4-bde24dc40a21",
+    "road": "Eteläinen Hesperiankatu"
+  },
+  {
+    "uid": "5edf9da1-b826-461c-a626-ffd419998cde",
+    "road": "Ehrenströmintie",
+    "house_number": "14"
+  },
+  {
+    "uid": "2433d587-bb45-4a78-9f7f-08f8033e4723",
+    "road": "Olympiaranta",
+    "house_number": "1"
+  },
+  {
+    "uid": "75fd994b-7e6d-491f-be8d-d5766b02a8ce",
+    "road": "Lönnrotinkatu",
+    "house_number": "42"
+  },
+  {
+    "uid": "ba171f35-df1a-4edb-ac8a-60d4b58e7332",
+    "road": "Temppelikatu"
+  },
+  {
+    "uid": "2535f004-afe6-4790-b6a4-c6cb2a269318",
+    "road": "Messipojankuja",
+    "house_number": "4"
+  },
+  {
+    "uid": "16e7b825-73ff-410f-9bb1-c67b42cc91f6",
+    "road": "Tuonelankuja",
+    "house_number": "3"
+  },
+  {
+    "uid": "2d0665d5-3e94-4344-9f80-eb696bf54fbb",
+    "road": "Pohjoinen Rautatiekatu",
+    "house_number": "23"
+  },
+  {
+    "uid": "6ec897d6-69d7-48dc-961e-284900052d86",
+    "road": "Eerikinkatu",
+    "house_number": "6"
+  },
+  {
+    "uid": "2bcf3b1f-8dc2-427d-86fc-1cce8faf8aa6",
+    "road": "Eerikinkatu"
+  },
+  {
+    "uid": "9c56ab3c-608e-4e83-b6e9-6f3ab075dc19",
+    "road": "Pohjoinen Rautatiekatu",
+    "house_number": "15"
+  },
+  {
+    "uid": "dc1f9559-cd96-412a-b1f6-8d287b3a6d89",
+    "road": "Pohjoinen Rautatiekatu",
+    "house_number": "17"
+  },
+  {
+    "uid": "e53bc830-bdd4-43aa-a5ba-995e4d581679",
+    "road": "Pohjoinen Rautatiekatu",
+    "house_number": "23"
+  },
+  {
+    "uid": "68798efe-1ac0-4f1b-b7bc-0b311770dd41",
+    "road": "Kanavakatu"
+  },
+  {
+    "uid": "96a1f674-cf72-402c-8f7a-7c10452848ea",
+    "road": "Kanavakatu"
+  },
+  {
+    "uid": "44bf8c52-6ca5-45d3-85aa-bbb7edbab2b5",
+    "road": "Laukkasaarenkatu"
+  },
+  {
+    "uid": "df0ad0c8-20c6-442f-b41d-d8e034195bfb",
+    "road": "Kanavakatu"
+  },
+  {
+    "uid": "ba7c4e69-12cc-4c85-bed1-5e0d4bddaf3e",
+    "road": "Pikku Satamakatu",
+    "house_number": "6"
+  },
+  {
+    "uid": "494fe009-c20d-470e-897e-f7b049f9f32c",
+    "road": "Perämiehenkatu",
+    "house_number": "2"
+  },
+  {
+    "uid": "c85fc2fd-ff4c-4d95-a338-1e2b6fafa958",
+    "road": "Selkämerenkatu",
+    "house_number": "11"
+  },
+  {
+    "uid": "17f9748e-5641-4c28-acb4-008061b0dda9",
+    "road": "Eteläesplanadi"
+  },
+  {
+    "uid": "48be8284-1923-4559-ac07-47d8e98066c9",
+    "road": "Itäinen Puistotie"
+  },
+  {
+    "uid": "df25c2eb-9c9a-459f-95da-5a5454c557d2",
+    "road": "Eteläranta"
+  },
+  {
+    "uid": "3cdcbbf8-309b-4772-825b-7dcf8b118e59",
+    "road": "Satamakatu"
+  },
+  {
+    "uid": "d4a6643f-de47-406b-8457-f7ad498c39ab",
+    "road": "Ehrenströmintie"
+  },
+  {
+    "uid": "01ee6c48-fad9-4e49-8554-a859bf298ceb",
+    "road": "Satamakatu"
+  },
+  {
+    "uid": "c10f3418-e8e3-4687-9185-80166f1eb73e",
+    "road": "Abrahaminkatu"
+  },
+  {
+    "uid": "8c039d7f-85d0-4ba1-96e0-546069f571ae",
+    "road": "Pohjoiskaari",
+    "house_number": "20"
+  },
+  {
+    "uid": "56c62c50-395a-45a5-b267-be88d8472036",
+    "road": "Telakkakatu"
+  },
+  {
+    "uid": "e145c601-1897-46d4-aca4-886f080f77e8",
+    "road": "Kaisaniemen puistokuja"
+  },
+  {
+    "uid": "df4a7bc3-026b-4d05-b4e9-3691a343f461",
+    "road": "Kirkkokatu"
+  },
+  {
+    "uid": "dbdc556c-ff32-4564-aba7-0f44a147572a",
+    "road": "Kirkkokatu",
+    "house_number": "14"
+  },
+  {
+    "uid": "00d3c0ab-2345-4241-82e5-8026f76c4c63",
+    "road": "Kirkkokatu"
+  },
+  {
+    "uid": "9d2f833c-6a85-481e-ba3f-39b65a0c5135",
+    "road": "Kirkkokatu"
+  },
+  {
+    "uid": "6ee5d7fc-7395-4db8-827f-143ee093821a",
+    "road": "Iso Puistotie",
+    "house_number": "1"
+  },
+  {
+    "uid": "86e4ff2f-a15b-48f8-a266-29ed9d0b3894",
+    "road": "Kirkkokatu"
+  },
+  {
+    "uid": "f92ace4d-d338-43b9-9ad8-0cab0131016d",
+    "road": "Itämerenkatu",
+    "house_number": "18"
+  },
+  {
+    "uid": "60bb1e77-cc56-4cca-bf22-0cf5e23b5af0",
+    "road": "Sinebrychoffinkatu",
+    "house_number": "13"
+  },
+  {
+    "uid": "8dd69747-1db4-4435-83b9-9945deca50d2",
+    "road": "Eteläinen Hesperiankatu"
+  }
+]

--- a/backend/src/routes/parking.js
+++ b/backend/src/routes/parking.js
@@ -157,7 +157,7 @@ router.get('/parking_area_statistics/uid/:uid', async (req, res) => {
  */
 router.get('/parking_area_statistics/popular/:limit/:hours', async (req, res) => {
     let result = []
-    const { limit, hours } = req.params // could supply here with date range rathen than days from now
+    const { limit, hours } = req.params // could supply here with date range rather than days from now
 
     try {
         if (hours / 24 < 1) throw 'Invalid hours!'
@@ -175,7 +175,7 @@ router.get('/parking_area_statistics/popular/:limit/:hours', async (req, res) =>
                 .coordinates[0][0][0] // change this
             // TODO: add the street name's
 
-            const history = await getParkingHistoryByUid(uid, hours) // make a func that accepts array
+            const history = await getParkingHistoryByUid(uid, hours) // should make a func that accepts array as looping and selecting is slow
             result.push({ ...history, long: coords[0], lat: coords[1], parking_sum })
         }
 

--- a/backend/src/routes/parking.js
+++ b/backend/src/routes/parking.js
@@ -152,6 +152,66 @@ router.get('/parking_area_statistics/uid/:uid', async (req, res) => {
 /**
  * @swagger
  * /api/parking_area_statistics/popular/{from}/{to}/{limit}/{offset}:
+ *   get:
+ *     summary: Get a list of parking areas' parking count in descending Order
+ *     description: Fetch parking statistics of the parking area.
+ *     parameters:
+ *       - in: path
+ *         name: from
+ *         schema:
+ *           type: date-time
+ *         required: true
+ *         description: date to start
+ *       - in: path
+ *         name: to
+ *         schema:
+ *           type: date-time
+ *         required: true
+ *         description: date to end
+ *       - in: path
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *         required: true
+ *         description: how many parking areas is shown
+ *       - in: path
+ *         name: offset
+ *         schema:
+ *           type: integer
+ *         required: true
+ *         description: a number of records you wish to skip before selecting parking area records.
+ *     responses:
+ *       200:
+ *         description: The requested parking area parking statistics
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   uid:
+ *                     type: string
+ *                   history:
+ *                     type: array
+ *                     items:
+ *                       allOf:
+ *                         - $ref: '#/components/schemas/Parking_Area_Statistics'
+ *                         - type: object
+ *                           properties:
+ *                             createdAt:
+ *                               type: date-time
+ *                               example: "2021-03-05T11:03:30.918941+00:00"
+ *                   parking_sum:
+ *                     type: string
+ *                   geometry:
+ *                     $ref: '#/components/definitions/MultiPolygon'
+ *                   capacity_estimate:
+ *                     type: integer
+ *       304:
+ *         description: The requested parking area statistics not modified
+ *       400:
+ *         description: Bad request
  *
  */
 router.get(

--- a/backend/src/routes/parking.js
+++ b/backend/src/routes/parking.js
@@ -5,7 +5,6 @@ const {
     getParkingAreas,
     getParkingHistoryByUid,
     getPopularParkingAreas,
-    getParkingAreasByArray,
 } = require('../database/queries/parking_area')
 const BASEURL = 'https://pubapi.parkkiopas.fi/public/v1'
 
@@ -162,10 +161,8 @@ router.get(
         if ((from, to, limit, offset)) {
             const fromDate = new Date(decodeURIComponent(from))
             const toDate = new Date(decodeURIComponent(to))
-            const hours = Math.abs(fromDate.getTime() - toDate.getTime()) / 36e5 // hours between these two dates
 
             try {
-                if (hours / 24 < 1) throw 'Invalid hours!'
                 const popularParkingAreas = await getPopularParkingAreas(
                     fromDate,
                     toDate,

--- a/backend/src/utils/getRoadNames.js
+++ b/backend/src/utils/getRoadNames.js
@@ -1,0 +1,42 @@
+const fs = require('fs')
+const axios = require('axios')
+const knex = require('../database/config')
+
+async function getRoad(lat, long) {
+    let address
+    await axios
+        .get(
+            'https://nominatim.openstreetmap.org/reverse?lat=' +
+                lat +
+                '&lon=' +
+                long +
+                '&format=json',
+        )
+        .then(response => {
+            address = response.data
+        })
+    return address.address
+}
+
+;(async () => {
+    const result = []
+    const data = await knex.from('parking_area').select()
+    console.log('This will take approx. ' + data.length + ' seconds.')
+    for (const feature of data) {
+        const long = feature.geometry.coordinates[0][0][0][0]
+        const lat = feature.geometry.coordinates[0][0][0][1]
+        const address = await getRoad(lat, long)
+        console.log(address)
+
+        result.push({
+            uid: feature.uid,
+            road: address.road,
+            house_number: address.house_number,
+        })
+        await new Promise(r => setTimeout(r, 1050))
+    }
+    fs.writeFileSync('./src/database/utils/roads.json', JSON.stringify(result, null, 2))
+
+    console.log('File wrote')
+    return
+})()

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12462,6 +12462,14 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
       "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew=="
     },
+    "react-infinite-scroll-component": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/react-infinite-scroll-component/-/react-infinite-scroll-component-6.0.0.tgz",
+      "integrity": "sha512-GK/amOgk4J/MLw8Kpp8K6MdDdX5QLJheVSSnhI6c2b6gvMwziCE2m1GDVrMyAyP7gDjgA0YH7pxdIoQya842LQ==",
+      "requires": {
+        "throttle-debounce": "^2.1.0"
+      }
+    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -14624,6 +14632,11 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
       "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA=="
+    },
+    "throttle-debounce": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-2.3.0.tgz",
+      "integrity": "sha512-H7oLPV0P7+jgvrk+6mwwwBDmxTaxnu9HMXmloNLXwnNO0ZxZ31Orah2n8lU1eMPvsaowP2CX+USCgyovXfdOFQ=="
     },
     "through2": {
       "version": "2.0.5",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1191,6 +1191,15 @@
         "@hapi/hoek": "^8.3.0"
       }
     },
+    "@hypnosphi/create-react-context": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@hypnosphi/create-react-context/-/create-react-context-0.3.1.tgz",
+      "integrity": "sha512-V1klUed202XahrWJLLOT3EXNeCpFHCcJntdFGI15ntCwau+jfT386w7OFTMaCqOgXUH1fa0w/I1oZs+i/Rfr0A==",
+      "requires": {
+        "gud": "^1.0.0",
+        "warning": "^4.0.3"
+      }
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -4834,6 +4843,11 @@
         "whatwg-url": "^8.0.0"
       }
     },
+    "date-fns": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.18.0.tgz",
+      "integrity": "sha512-NYyAg4wRmGVU4miKq5ivRACOODdZRY3q5WLmOJSq8djyzftYphU7dTHLcEtLqEvfqMKQ0jVv91P4BAwIjsXIcw=="
+    },
     "debug": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
@@ -6987,6 +7001,11 @@
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "optional": true
+    },
+    "gud": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
+      "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
     },
     "gzip-size": {
       "version": "5.1.1",
@@ -10976,6 +10995,11 @@
         "ts-pnp": "^1.1.6"
       }
     },
+    "popper.js": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
+      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
+    },
     "portfinder": {
       "version": "1.0.28",
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.28.tgz",
@@ -12296,6 +12320,18 @@
         "whatwg-fetch": "^3.4.1"
       }
     },
+    "react-datepicker": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-3.6.0.tgz",
+      "integrity": "sha512-QCCtC1Y5kXZSbULbP33P2p0yTU+0Det7eBFABVM2k6AqdIvyBHVkO/hlq2WDeHlPtaf+DEniCIYjrv2BFdUMHw==",
+      "requires": {
+        "classnames": "^2.2.6",
+        "date-fns": "^2.0.1",
+        "prop-types": "^15.7.2",
+        "react-onclickoutside": "^6.10.0",
+        "react-popper": "^1.3.8"
+      }
+    },
     "react-dev-utils": {
       "version": "11.0.2",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-11.0.2.tgz",
@@ -12443,6 +12479,24 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "react-onclickoutside": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.10.0.tgz",
+      "integrity": "sha512-7i2L3ef+0ILXpL6P+Hg304eCQswh4jl3ynwR71BSlMU49PE2uk31k8B2GkP6yE9s2D4jTGKnzuSpzWxu4YxfQQ=="
+    },
+    "react-popper": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.10.tgz",
+      "integrity": "sha512-sZfwHtHCMst0L0G/c83/Y/K1f9fNWMEKsk/cGAor68rQBHB75WuDQ7k95tkce8QNaUHhg9uFXIJbZO0eWRvJbw==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "@hypnosphi/create-react-context": "^0.3.1",
+        "popper.js": "^1.14.4",
+        "prop-types": "^15.6.1",
+        "typed-styles": "^0.0.7",
+        "warning": "^4.0.2"
+      }
     },
     "react-refresh": {
       "version": "0.8.3",
@@ -14791,6 +14845,11 @@
         "mime-types": "~2.1.24"
       }
     },
+    "typed-styles": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/typed-styles/-/typed-styles-0.0.7.tgz",
+      "integrity": "sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q=="
+    },
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -15144,6 +15203,14 @@
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
       "requires": {
         "makeerror": "1.0.x"
+      }
+    },
+    "warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "requires": {
+        "loose-envify": "^1.0.0"
       }
     },
     "watchpack": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "react-datepicker": "^3.6.0",
     "react-dom": "^17.0.1",
     "react-draggable": "^4.4.3",
+    "react-infinite-scroll-component": "^6.0.0",
     "react-leaflet": "^3.1.0",
     "react-scripts": "4.0.2",
     "recharts": "^2.0.7",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "axios": "^0.21.1",
     "leaflet": "^1.7.1",
     "react": "^17.0.1",
+    "react-datepicker": "^3.6.0",
     "react-dom": "^17.0.1",
     "react-draggable": "^4.4.3",
     "react-leaflet": "^3.1.0",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,29 +1,37 @@
-import React, { useReducer } from "react"
+import React, { useReducer } from 'react'
 
-import Map from "./components/Map/"
-import Window from "./components/Window/"
+import Map from './components/Map/'
+import Window from './components/Window/'
 
 import {
     ParkingDataContext,
     parkingDataInitialState,
     parkingDataReducer,
-} from "./context/parking_data"
+} from './context/parking_data'
+
+import { MapContext, mapInitialState, mapReducer } from './context/map'
 
 export default function App() {
-    const [parkingDataState, parkingDataDispatch] = React.useReducer(
+    const [parkingDataState, parkingDataDispatch] = useReducer(
         parkingDataReducer,
-        parkingDataInitialState
+        parkingDataInitialState,
     )
+    const [mapState, mapDispatch] = useReducer(mapReducer, mapInitialState)
 
     return (
         <ParkingDataContext.Provider
             value={{
                 parkingDataState,
                 parkingDataDispatch,
-            }}
-        >
-            <Map />
-            <Window />
+            }}>
+            <MapContext.Provider
+                value={{
+                    mapState,
+                    mapDispatch,
+                }}>
+                <Map />
+                <Window />
+            </MapContext.Provider>
         </ParkingDataContext.Provider>
     )
 }

--- a/frontend/src/components/Map/index.jsx
+++ b/frontend/src/components/Map/index.jsx
@@ -50,6 +50,7 @@ export default function Map() {
                     payload: {
                         capacity_estimate: properties.capacity_estimate,
                         uid: properties.uid,
+                        statistics: false,
                     },
                 })
 

--- a/frontend/src/components/Map/index.jsx
+++ b/frontend/src/components/Map/index.jsx
@@ -6,11 +6,14 @@ import { getParkingLocations } from '../../services/parking'
 
 import { ParkingDataContext } from '../../context/parking_data'
 
+import { MapContext } from '../../context/map'
+
 export default function Map() {
     const {
         parkingDataState: { filtered },
         parkingDataDispatch,
     } = useContext(ParkingDataContext)
+    const { mapDispatch } = useContext(MapContext)
     const geoJsonLayer = useRef(null)
 
     useEffect(() => {
@@ -43,8 +46,12 @@ export default function Map() {
             },
         })
     }
+
     return (
-        <MapContainer center={[60.1699, 24.9384]} zoom={13}>
+        <MapContainer
+            center={[60.1699, 24.9384]}
+            zoom={13}
+            whenCreated={map => mapDispatch({ type: 'SET_MAP', payload: map })}>
             <TileLayer
                 attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
                 url='https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'

--- a/frontend/src/components/Map/index.jsx
+++ b/frontend/src/components/Map/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useContext, useRef } from 'react'
+import React, { useState, useEffect, useContext, useRef } from 'react'
 
 import { MapContainer, TileLayer, GeoJSON } from 'react-leaflet'
 
@@ -13,7 +13,10 @@ export default function Map() {
         parkingDataState: { filtered },
         parkingDataDispatch,
     } = useContext(ParkingDataContext)
-    const { mapDispatch } = useContext(MapContext)
+    const {
+        mapState: { highlight, reset },
+        mapDispatch,
+    } = useContext(MapContext)
     const geoJsonLayer = useRef(null)
 
     useEffect(() => {
@@ -26,10 +29,16 @@ export default function Map() {
     }, [parkingDataDispatch])
 
     useEffect(() => {
-        if (geoJsonLayer.current) {
-            geoJsonLayer.current.clearLayers().addData(filtered)
-        }
+        geoJsonLayer.current?.clearLayers().addData(filtered)
     }, [filtered])
+
+    useEffect(() => {
+        highlight?.setStyle({ color: 'red' })
+    }, [highlight])
+
+    useEffect(() => {
+        geoJsonLayer.current?.resetStyle(reset)
+    }, [reset])
 
     const onEachFeature = (feature, layer) => {
         layer.on({
@@ -43,6 +52,8 @@ export default function Map() {
                         uid: properties.uid,
                     },
                 })
+
+                mapDispatch({ type: 'HIGHLIGHT', payload: { highlight: layer } })
             },
         })
     }

--- a/frontend/src/components/Window/Filter/index.jsx
+++ b/frontend/src/components/Window/Filter/index.jsx
@@ -63,7 +63,7 @@ export default function Filter() {
             <br />
             Parking capacity (estimate):
             <br />
-            <div className='disable'>
+            <div className='disable' style={{ cursor: 'pointer' }}>
                 <select onChange={e => setOperator(e.target.value)}>
                     <option value='more than'>More than</option>
                     <option value='less than'>Less than</option>

--- a/frontend/src/components/Window/Filter/index.jsx
+++ b/frontend/src/components/Window/Filter/index.jsx
@@ -58,7 +58,7 @@ export default function Filter() {
     }, [checkbox, locations, operator, parkingDataDispatch, slider])
 
     return (
-        <>
+        <div style={{ backgroundColor: 'white', padding: 10 }}>
             Filters:
             <br />
             Parking capacity (estimate):
@@ -87,6 +87,6 @@ export default function Filter() {
                     onChange={event => setCheckbox(event.target.checked)}
                 />
             </div>
-        </>
+        </div>
     )
 }

--- a/frontend/src/components/Window/Graph/index.jsx
+++ b/frontend/src/components/Window/Graph/index.jsx
@@ -1,23 +1,32 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useState, useContext } from 'react'
 
 import { LineChart, Line, CartesianGrid, XAxis, YAxis, Tooltip } from 'recharts'
 
 import { getParkingHistory } from '../../../services/parking'
 
-export default function Graph({ uid, history }) {
-    const [parkingHistory, setParkingHistory] = useState(null)
+import { ParkingDataContext } from '../../../context/parking_data'
+
+export default function Graph() {
+    const {
+        parkingDataState: {
+            selected: { uid, statistics },
+            history,
+        },
+        parkingDataDispatch,
+    } = useContext(ParkingDataContext)
     const [limit, setLimit] = useState(24)
 
     useEffect(() => {
         ;(async () => {
-            if (uid && !history) {
+            if (!statistics) {
                 const current_parking_history = await getParkingHistory(uid, limit)
-                setParkingHistory(current_parking_history)
-            } else {
-                setParkingHistory(history)
+                parkingDataDispatch({
+                    type: 'SET_HISTORY',
+                    payload: current_parking_history,
+                })
             }
         })()
-    }, [history, limit, uid])
+    }, [limit, parkingDataDispatch, statistics, uid])
 
     const CustomTooltip = ({ active, payload, label }) => {
         if (active && payload && payload.length) {
@@ -51,7 +60,7 @@ export default function Graph({ uid, history }) {
                 width={400}
                 height={380}
                 margin={{ right: 15, top: 5 }}
-                data={parkingHistory}>
+                data={history}>
                 <Line type='monotone' dataKey='current_parking_count' stroke='#8884d8' />
                 <CartesianGrid stroke='#ccc' strokeDasharray='1 1' />
                 <XAxis
@@ -66,7 +75,8 @@ export default function Graph({ uid, history }) {
                 <YAxis width={30} dataKey='current_parking_count' />
                 <Tooltip content={CustomTooltip} />
             </LineChart>
-            {uid && (
+
+            {!statistics && (
                 <label style={{ paddingLeft: '150px' }}>
                     limit:
                     <select

--- a/frontend/src/components/Window/Graph/index.jsx
+++ b/frontend/src/components/Window/Graph/index.jsx
@@ -4,24 +4,20 @@ import { LineChart, Line, CartesianGrid, XAxis, YAxis, Tooltip } from 'recharts'
 
 import { getParkingHistory } from '../../../services/parking'
 
-export default function Graph({ uid, propsParkingHistory }) {
+export default function Graph({ uid, history }) {
     const [parkingHistory, setParkingHistory] = useState(null)
     const [limit, setLimit] = useState(24)
 
     useEffect(() => {
-        if (propsParkingHistory) {
-            setParkingHistory(propsParkingHistory)
-        }
-    }, [propsParkingHistory])
-
-    useEffect(() => {
         ;(async () => {
-            if (uid) {
+            if (uid && !history) {
                 const current_parking_history = await getParkingHistory(uid, limit)
                 setParkingHistory(current_parking_history)
+            } else {
+                setParkingHistory(history)
             }
         })()
-    }, [limit, uid])
+    }, [history, limit, uid])
 
     const CustomTooltip = ({ active, payload, label }) => {
         if (active && payload && payload.length) {

--- a/frontend/src/components/Window/Graph/index.jsx
+++ b/frontend/src/components/Window/Graph/index.jsx
@@ -1,61 +1,88 @@
 import React, { useEffect, useState } from 'react'
 
-import { LineChart, Line, CartesianGrid, XAxis, YAxis, Tooltip } from 'recharts';
+import { LineChart, Line, CartesianGrid, XAxis, YAxis, Tooltip } from 'recharts'
 
 import { getParkingHistory } from '../../../services/parking'
 
-export default function Graph({ uid }) {
+export default function Graph({ uid, propsParkingHistory }) {
     const [parkingHistory, setParkingHistory] = useState(null)
     const [limit, setLimit] = useState(24)
+
     useEffect(() => {
-        ; (async () => {
+        if (propsParkingHistory) {
+            setParkingHistory(propsParkingHistory)
+        }
+    }, [propsParkingHistory])
+
+    useEffect(() => {
+        ;(async () => {
             if (uid) {
                 const current_parking_history = await getParkingHistory(uid, limit)
                 setParkingHistory(current_parking_history)
             }
         })()
-    }, [uid, limit])
+    }, [limit, uid])
 
     const CustomTooltip = ({ active, payload, label }) => {
         if (active && payload && payload.length) {
             const date = new Date(label)
-            const labelDate = date.getDate() + "-" + (date.getMonth() + 1) + "-" + date.getFullYear()
-            label = date.getUTCHours() + 2 + ".00"
+            const labelDate =
+                date.getDate() + '-' + (date.getMonth() + 1) + '-' + date.getFullYear()
+            label = date.getUTCHours() + 2 + '.00'
             return (
-                <div style={{ backgroundColor: "white", opacity: "90%", }} className="custom-tooltip">
-                    <p className="label">{`date: ${labelDate}`}</p>
-                    <p className="label">{`time: ${label}`}</p>
-                    <p className="label">{`parking count: ${payload[0].value}`}</p>
+                <div
+                    style={{ backgroundColor: 'white', opacity: '90%' }}
+                    className='custom-tooltip'>
+                    <p className='label'>{`date: ${labelDate}`}</p>
+                    <p className='label'>{`time: ${label}`}</p>
+                    <p className='label'>{`parking count: ${payload[0].value}`}</p>
                 </div>
-            );
+            )
         }
-        return null;
-    };
+        return null
+    }
     return (
         <div
             style={{
-                backgroundColor: "white",
-                display: "inline-block",
-                width: "400px",
-                height: "400px",
+                backgroundColor: 'white',
+                display: 'inline-block',
+                width: '400px',
+                height: '400px',
                 marginTop: 3,
-                overflow: "auto",
-                marginLeft: "0",
+                overflow: 'auto',
+                marginLeft: '0',
             }}>
-            <LineChart width={400} height={380} margin={{ right: 15, top: 5 }} data={parkingHistory}>
-                <Line type="monotone" dataKey="current_parking_count" stroke="#8884d8" />
-                <CartesianGrid stroke="#ccc" strokeDasharray="1 1" />
-                <XAxis reversed={true} dataKey="created_at" tickFormatter={(formtime) => new Date(formtime).toLocaleTimeString(["en-US"], { hour: '2-digit' })} />
-                <YAxis width={30} dataKey="current_parking_count" />
+            <LineChart
+                width={400}
+                height={380}
+                margin={{ right: 15, top: 5 }}
+                data={parkingHistory}>
+                <Line type='monotone' dataKey='current_parking_count' stroke='#8884d8' />
+                <CartesianGrid stroke='#ccc' strokeDasharray='1 1' />
+                <XAxis
+                    reversed={true}
+                    dataKey='created_at'
+                    tickFormatter={formtime =>
+                        new Date(formtime).toLocaleTimeString(['en-US'], {
+                            hour: '2-digit',
+                        })
+                    }
+                />
+                <YAxis width={30} dataKey='current_parking_count' />
                 <Tooltip content={CustomTooltip} />
             </LineChart>
-            <label style={{ paddingLeft: "150px" }}> limit:
-            <select defaultValue="24" onChange={e => setLimit(parseInt(e.target.value))}>
-                    <option value="12">12h</option>
-                    <option value="24">24h</option>
-                    <option value="168">7d</option>
-                </select>
-            </label>
+            {uid && (
+                <label style={{ paddingLeft: '150px' }}>
+                    limit:
+                    <select
+                        defaultValue='24'
+                        onChange={e => setLimit(parseInt(e.target.value))}>
+                        <option value='12'>12h</option>
+                        <option value='24'>24h</option>
+                        <option value='168'>7d</option>
+                    </select>
+                </label>
+            )}
         </div>
     )
 }

--- a/frontend/src/components/Window/Graph/index.jsx
+++ b/frontend/src/components/Window/Graph/index.jsx
@@ -48,7 +48,6 @@ export default function Graph({ uid, propsParkingHistory }) {
                 display: 'inline-block',
                 width: '400px',
                 height: '400px',
-                marginTop: 3,
                 overflow: 'auto',
                 marginLeft: '0',
             }}>

--- a/frontend/src/components/Window/Selected/index.jsx
+++ b/frontend/src/components/Window/Selected/index.jsx
@@ -1,0 +1,39 @@
+import React, { useState, useEffect } from 'react'
+
+import { getParkingStatistics } from '../../../services/parking'
+
+export default function Selected({ selected }) {
+    const [parkingStatistics, setParkingStatistics] = useState(null)
+
+    useEffect(() => {
+        ;(async () => {
+            if (selected.uid) {
+                const { current_parking_count } = await getParkingStatistics(selected.uid)
+                setParkingStatistics(current_parking_count)
+            }
+        })()
+    }, [selected])
+
+    return (
+        <>
+            {selected && (
+                <div
+                    style={{
+                        backgroundColor: 'white',
+                        display: 'inline-block',
+                        width: '200px',
+                        padding: 10,
+                        marginTop: 3,
+                        marginBottom: 3,
+                        textAlign: 'center',
+                    }}>
+                    uid: {selected.uid}
+                    <br />
+                    capacity estimate: {selected?.capacity_estimate || 'unknown'}
+                    <br />
+                    current parking count: {parkingStatistics}
+                </div>
+            )}
+        </>
+    )
+}

--- a/frontend/src/components/Window/Statistics/index.jsx
+++ b/frontend/src/components/Window/Statistics/index.jsx
@@ -40,7 +40,7 @@ export default function Statistics() {
                 uid: item.uid,
                 list: item.history,
             })
-            const coords = [...item.geometry.coordinates[0][0].map(arr => arr.reverse())] // clone geojson array and reverse the coords
+            const coords = item.geometry.coordinates[0][0].map(arr => [...arr].reverse()) // map and copy coords, then reverse the arr since they are geojson
             map.flyToBounds(coords, 19)
 
             const layer = Object.values(map._layers).find(

--- a/frontend/src/components/Window/Statistics/index.jsx
+++ b/frontend/src/components/Window/Statistics/index.jsx
@@ -8,9 +8,7 @@ import InfiniteScroll from 'react-infinite-scroll-component'
 import { getPopularParkingAreas } from '../../../services/parking'
 
 import { MapContext } from '../../../context/map'
-
-import Graph from '../Graph'
-import Selected from '../Selected'
+import { ParkingDataContext } from '../../../context/parking_data'
 
 export default function Statistics() {
     const [statistics, setStatistics] = useState([])
@@ -20,11 +18,15 @@ export default function Statistics() {
     const [toDate, setToDate] = useState(new Date())
     const [limit, setLimit] = useState(5)
     const [offset, setOffset] = useState(0)
-    const [history, setHistory] = useState(null)
+
     const {
         mapState: { map },
         mapDispatch,
     } = useContext(MapContext)
+    const {
+        parkingDataState: { selected },
+        parkingDataDispatch,
+    } = useContext(ParkingDataContext)
 
     useEffect(() => {
         ;(async () => {
@@ -34,14 +36,15 @@ export default function Statistics() {
     }, [fromDate, toDate, limit, offset])
 
     const handleSelectParking = item => {
-        if (item.uid === history?.uid) {
-            setHistory(null)
+        if (item.uid === selected?.uid) {
+            parkingDataDispatch({ type: 'SET_HISTORY', payload: [] })
         } else {
-            setHistory({
-                uid: item.uid,
-                list: item.history,
-                capacity_estimate: item.capacity_estimate,
+            parkingDataDispatch({
+                type: 'SET_PARKING_DATA',
+                payload: { uid: item.uid, capacity_estimate: item.capacity_estimate },
             })
+            parkingDataDispatch({ type: 'SET_HISTORY', payload: item.history })
+
             const coords = item.geometry.coordinates[0][0].map(arr => [...arr].reverse()) // map and copy coords, then reverse the arr since they are geojson
             map.flyToBounds(coords, 19)
 
@@ -98,17 +101,6 @@ export default function Statistics() {
                     </div>
                 ))}
             </InfiniteScroll>
-            {history?.list && (
-                <>
-                    <Selected
-                        selected={{
-                            uid: history.uid,
-                            capacity_estimate: history.capacity_estimate,
-                        }}
-                    />
-                    <Graph propsParkingHistory={history.list} />
-                </>
-            )}
         </div>
     )
 }

--- a/frontend/src/components/Window/Statistics/index.jsx
+++ b/frontend/src/components/Window/Statistics/index.jsx
@@ -39,10 +39,11 @@ export default function Statistics() {
                 uid: item.uid,
                 list: item.history,
             })
-            const coords = [...item.geometry.coordinates[0][0][0]] // clone one corner of a polygon
-            map.flyTo(coords.reverse(), 17) // needs to be reversed as it's geojson
+            const coords = [...item.geometry.coordinates[0][0].map(arr => arr.reverse())] // clone geojson array and reverse the coords
+            map.flyToBounds(coords, 19)
         }
     }
+
     return (
         <div style={{ width: 400 }}>
             <DatePicker selected={fromDate} onChange={date => setFromDate(date)} />

--- a/frontend/src/components/Window/Statistics/index.jsx
+++ b/frontend/src/components/Window/Statistics/index.jsx
@@ -28,7 +28,7 @@ export default function Statistics() {
     useEffect(() => {
         ;(async () => {
             const data = await getPopularParkingAreas(fromDate, toDate, limit, offset)
-            setStatistics(stats => [...stats, ...data])
+            offset > 0 ? setStatistics(stats => [...stats, ...data]) : setStatistics(data)
         })()
     }, [fromDate, toDate, limit, offset])
 
@@ -52,8 +52,14 @@ export default function Statistics() {
 
     return (
         <div style={{ width: 400 }}>
-            <DatePicker selected={fromDate} onChange={date => setFromDate(date)} />
-            <DatePicker selected={toDate} onChange={date => setToDate(date)} />
+            <DatePicker
+                selected={fromDate}
+                onChange={date => (setOffset(0), setFromDate(date))}
+            />
+            <DatePicker
+                selected={toDate}
+                onChange={date => (setOffset(0), setToDate(date))}
+            />
             <InfiniteScroll
                 dataLength={statistics.length}
                 next={() => setOffset(offset + limit)}

--- a/frontend/src/components/Window/Statistics/index.jsx
+++ b/frontend/src/components/Window/Statistics/index.jsx
@@ -22,6 +22,7 @@ export default function Statistics() {
     const [history, setHistory] = useState(null)
     const {
         mapState: { map },
+        mapDispatch,
     } = useContext(MapContext)
 
     useEffect(() => {
@@ -41,6 +42,11 @@ export default function Statistics() {
             })
             const coords = [...item.geometry.coordinates[0][0].map(arr => arr.reverse())] // clone geojson array and reverse the coords
             map.flyToBounds(coords, 19)
+
+            const layer = Object.values(map._layers).find(
+                layer => layer.feature?.properties.uid === item.uid,
+            ) // probs bad
+            mapDispatch({ type: 'HIGHLIGHT', payload: { highlight: layer } })
         }
     }
 

--- a/frontend/src/components/Window/Statistics/index.jsx
+++ b/frontend/src/components/Window/Statistics/index.jsx
@@ -1,0 +1,62 @@
+import React, { useState, useEffect } from 'react'
+
+import DatePicker from 'react-datepicker'
+import 'react-datepicker/dist/react-datepicker.css'
+
+import { getPopularParkingAreas } from '../../../services/parking'
+
+import Graph from '../Graph'
+
+export default function Statistics() {
+    const [statistics, setStatistics] = useState([])
+    const [fromDate, setFromDate] = useState(
+        new Date(new Date().setDate(new Date().getDate() - 1)),
+    )
+    const [toDate, setToDate] = useState(new Date())
+    const [limit, setLimit] = useState(5) // TODO
+    const [offset, setOffset] = useState(0) // TODO
+    const [history, setHistory] = useState(null)
+
+    useEffect(() => {
+        ;(async () => {
+            setStatistics(await getPopularParkingAreas(fromDate, toDate, limit, offset))
+        })()
+    }, [fromDate, toDate, limit, offset])
+
+    return (
+        <div>
+            <DatePicker selected={fromDate} onChange={date => setFromDate(date)} />
+            <DatePicker selected={toDate} onChange={date => setToDate(date)} />
+            {statistics.map(item => (
+                <div
+                    style={{
+                        display: 'flex',
+                        justifyContent: 'center',
+                        margin: 'auto',
+                        flexDirection: 'column',
+                    }}>
+                    <div
+                        style={{
+                            backgroundColor: 'grey',
+                            width: '100%',
+                            cursor: 'pointer',
+                            marginBottom: 5,
+                            marginTop: 5,
+                            height: 40,
+                        }}
+                        onClick={() =>
+                            item.uid === history?.uid
+                                ? setHistory(null)
+                                : setHistory({
+                                      uid: item.uid,
+                                      list: item.history,
+                                  })
+                        }>
+                        total: {item.parking_sum}
+                    </div>
+                </div>
+            ))}
+            {history?.list && <Graph propsParkingHistory={history.list} />}
+        </div>
+    )
+}

--- a/frontend/src/components/Window/Statistics/index.jsx
+++ b/frontend/src/components/Window/Statistics/index.jsx
@@ -10,6 +10,7 @@ import { getPopularParkingAreas } from '../../../services/parking'
 import { MapContext } from '../../../context/map'
 
 import Graph from '../Graph'
+import Selected from '../Selected'
 
 export default function Statistics() {
     const [statistics, setStatistics] = useState([])
@@ -39,6 +40,7 @@ export default function Statistics() {
             setHistory({
                 uid: item.uid,
                 list: item.history,
+                capacity_estimate: item.capacity_estimate,
             })
             const coords = item.geometry.coordinates[0][0].map(arr => [...arr].reverse()) // map and copy coords, then reverse the arr since they are geojson
             map.flyToBounds(coords, 19)
@@ -96,7 +98,17 @@ export default function Statistics() {
                     </div>
                 ))}
             </InfiniteScroll>
-            {history?.list && <Graph propsParkingHistory={history.list} />}
+            {history?.list && (
+                <>
+                    <Selected
+                        selected={{
+                            uid: history.uid,
+                            capacity_estimate: history.capacity_estimate,
+                        }}
+                    />
+                    <Graph propsParkingHistory={history.list} />
+                </>
+            )}
         </div>
     )
 }

--- a/frontend/src/components/Window/Statistics/index.jsx
+++ b/frontend/src/components/Window/Statistics/index.jsx
@@ -27,7 +27,7 @@ export default function Statistics() {
     } = useContext(MapContext)
 
     useEffect(() => {
-        ;(async () => {
+        ; (async () => {
             const data = await getPopularParkingAreas(fromDate, toDate, limit, offset)
             offset > 0 ? setStatistics(stats => [...stats, ...data]) : setStatistics(data)
         })()
@@ -44,7 +44,6 @@ export default function Statistics() {
             })
             const coords = item.geometry.coordinates[0][0].map(arr => [...arr].reverse()) // map and copy coords, then reverse the arr since they are geojson
             map.flyToBounds(coords, 19)
-
             const layer = Object.values(map._layers).find(
                 layer => layer.feature?.properties.uid === item.uid,
             ) // probs bad

--- a/frontend/src/components/Window/Statistics/index.jsx
+++ b/frontend/src/components/Window/Statistics/index.jsx
@@ -41,7 +41,11 @@ export default function Statistics() {
         } else {
             parkingDataDispatch({
                 type: 'SET_PARKING_DATA',
-                payload: { uid: item.uid, capacity_estimate: item.capacity_estimate },
+                payload: {
+                    uid: item.uid,
+                    capacity_estimate: item.capacity_estimate,
+                    statistics: true,
+                },
             })
             parkingDataDispatch({ type: 'SET_HISTORY', payload: item.history })
 

--- a/frontend/src/components/Window/index.jsx
+++ b/frontend/src/components/Window/index.jsx
@@ -4,30 +4,20 @@ import Draggable from 'react-draggable'
 
 import { ParkingDataContext } from '../../context/parking_data'
 
-import { getParkingStatistics } from '../../services/parking'
-
 import Graph from '../Window/Graph/index'
 
 import Filter from './Filter'
 import Statistics from './Statistics'
+import Selected from './Selected'
 
 export default function Window() {
-    const [parkingStatistics, setParkingStatistics] = useState(null)
-    const [current, setCurrent] = useState(true)
+    const [filters, setFilters] = useState(true)
     const [statistics, setStatistics] = useState(false)
 
     const {
         parkingDataState: { selected },
     } = useContext(ParkingDataContext)
 
-    useEffect(() => {
-        ;(async () => {
-            if (selected.uid) {
-                const { current_parking_count } = await getParkingStatistics(selected.uid)
-                setParkingStatistics(current_parking_count)
-            }
-        })()
-    }, [selected])
     return (
         <Draggable
             defaultPosition={{ x: 0, y: 0 }}
@@ -43,10 +33,10 @@ export default function Window() {
                     cursor: 'grab',
                 }}>
                 <div style={{ marginBottom: 3 }}>
-                    <button onClick={() => (setCurrent(true), setStatistics(false))}>
-                        Current
+                    <button onClick={() => (setFilters(true), setStatistics(false))}>
+                        Filters
                     </button>
-                    <button onClick={() => (setCurrent(false), setStatistics(true))}>
+                    <button onClick={() => (setFilters(false), setStatistics(true))}>
                         Statistics
                     </button>
                 </div>
@@ -57,29 +47,12 @@ export default function Window() {
                         alignItems: 'center',
                         textAlign: 'center',
                     }}>
-                    {current && (
+                    {filters && (
                         <>
                             <Filter />
-
                             {selected.uid && (
                                 <>
-                                    <div
-                                        style={{
-                                            backgroundColor: 'white',
-                                            display: 'inline-block',
-                                            width: '200px',
-                                            padding: 10,
-                                            marginTop: 3,
-                                            marginBottom: 3,
-                                            textAlign: 'center',
-                                        }}>
-                                        uid: {selected?.uid}
-                                        <br />
-                                        capacity estimate:{' '}
-                                        {selected?.capacity_estimate || 'unknown'}
-                                        <br />
-                                        current parking count: {parkingStatistics}
-                                    </div>
+                                    <Selected selected={selected} />
                                     <Graph uid={selected.uid} />
                                 </>
                             )}

--- a/frontend/src/components/Window/index.jsx
+++ b/frontend/src/components/Window/index.jsx
@@ -15,7 +15,7 @@ export default function Window() {
     const [statistics, setStatistics] = useState(false)
 
     const {
-        parkingDataState: { selected },
+        parkingDataState: { selected, history },
     } = useContext(ParkingDataContext)
 
     return (
@@ -47,18 +47,14 @@ export default function Window() {
                         alignItems: 'center',
                         textAlign: 'center',
                     }}>
-                    {filters && (
+                    {filters && <Filter />}
+                    {statistics && <Statistics />}
+                    {selected.uid && (
                         <>
-                            <Filter />
-                            {selected.uid && (
-                                <>
-                                    <Selected selected={selected} />
-                                    <Graph uid={selected.uid} />
-                                </>
-                            )}
+                            <Selected selected={selected} />
+                            <Graph uid={selected.uid} history={history} />
                         </>
                     )}
-                    {statistics && <Statistics />}
                 </div>
             </div>
         </Draggable>

--- a/frontend/src/components/Window/index.jsx
+++ b/frontend/src/components/Window/index.jsx
@@ -9,16 +9,19 @@ import { getParkingStatistics } from '../../services/parking'
 import Graph from '../Window/Graph/index'
 
 import Filter from './Filter'
+import Statistics from './Statistics'
 
 export default function Window() {
     const [parkingStatistics, setParkingStatistics] = useState(null)
+    const [current, setCurrent] = useState(true)
+    const [statistics, setStatistics] = useState(false)
 
     const {
         parkingDataState: { selected },
     } = useContext(ParkingDataContext)
 
     useEffect(() => {
-        ; (async () => {
+        ;(async () => {
             if (selected.uid) {
                 const { current_parking_count } = await getParkingStatistics(selected.uid)
                 setParkingStatistics(current_parking_count)
@@ -37,7 +40,16 @@ export default function Window() {
                     flexDirection: 'column',
                     alignItems: 'center',
                     position: 'absolute',
+                    cursor: 'grab',
                 }}>
+                <div style={{ marginBottom: 3 }}>
+                    <button onClick={() => (setCurrent(true), setStatistics(false))}>
+                        Current
+                    </button>
+                    <button onClick={() => (setCurrent(false), setStatistics(true))}>
+                        Statistics
+                    </button>
+                </div>
                 <div
                     style={{
                         backgroundColor: 'white',
@@ -47,24 +59,34 @@ export default function Window() {
                         marginBottom: 3,
                         textAlign: 'center',
                     }}>
-                    <Filter />
+                    {current && (
+                        <>
+                            <Filter />
+
+                            {selected.uid && (
+                                <>
+                                    <div
+                                        style={{
+                                            backgroundColor: 'white',
+                                            display: 'inline-block',
+                                            width: '200px',
+                                            padding: 10,
+                                            textAlign: 'center',
+                                        }}>
+                                        uid: {selected?.uid}
+                                        <br />
+                                        capacity estimate:{' '}
+                                        {selected?.capacity_estimate || 'unknown'}
+                                        <br />
+                                        current parking count: {parkingStatistics}
+                                    </div>
+                                    <Graph uid={selected.uid} />
+                                </>
+                            )}
+                        </>
+                    )}
+                    {statistics && <Statistics />}
                 </div>
-                <div
-                    style={{
-                        backgroundColor: 'white',
-                        display: 'inline-block',
-                        width: '200px',
-                        padding: 10,
-                        textAlign: 'center',
-                    }}>
-                    uid: {selected?.uid}
-                    <br />
-                    capacity estimate: {selected?.capacity_estimate || 'unknown'}
-                    <br />
-                    current parking count: {parkingStatistics}
-                </div>
-                {selected.uid && <Graph uid={selected.uid} />
-                }
             </div>
         </Draggable>
     )

--- a/frontend/src/components/Window/index.jsx
+++ b/frontend/src/components/Window/index.jsx
@@ -52,11 +52,9 @@ export default function Window() {
                 </div>
                 <div
                     style={{
-                        backgroundColor: 'white',
-                        display: 'inline-block',
-                        width: '300px',
-                        padding: 10,
-                        marginBottom: 3,
+                        display: 'flex',
+                        flexDirection: 'column',
+                        alignItems: 'center',
                         textAlign: 'center',
                     }}>
                     {current && (
@@ -71,6 +69,8 @@ export default function Window() {
                                             display: 'inline-block',
                                             width: '200px',
                                             padding: 10,
+                                            marginTop: 3,
+                                            marginBottom: 3,
                                             textAlign: 'center',
                                         }}>
                                         uid: {selected?.uid}

--- a/frontend/src/components/Window/index.jsx
+++ b/frontend/src/components/Window/index.jsx
@@ -15,7 +15,7 @@ export default function Window() {
     const [statistics, setStatistics] = useState(false)
 
     const {
-        parkingDataState: { selected, history },
+        parkingDataState: { selected },
     } = useContext(ParkingDataContext)
 
     return (
@@ -52,7 +52,7 @@ export default function Window() {
                     {selected.uid && (
                         <>
                             <Selected selected={selected} />
-                            <Graph uid={selected.uid} history={history} />
+                            <Graph />
                         </>
                     )}
                 </div>

--- a/frontend/src/context/map.js
+++ b/frontend/src/context/map.js
@@ -4,6 +4,8 @@ export const MapContext = React.createContext()
 
 export const mapInitialState = {
     map: null,
+    highlight: null,
+    reset: null,
 }
 
 export const mapReducer = (state, action) => {
@@ -12,6 +14,12 @@ export const mapReducer = (state, action) => {
             return {
                 ...state,
                 map: action.payload,
+            }
+        case 'HIGHLIGHT':
+            return {
+                ...state,
+                highlight: action.payload.highlight,
+                reset: state.highlight,
             }
         default:
             return state

--- a/frontend/src/context/map.js
+++ b/frontend/src/context/map.js
@@ -1,0 +1,19 @@
+import React from 'react'
+
+export const MapContext = React.createContext()
+
+export const mapInitialState = {
+    map: null,
+}
+
+export const mapReducer = (state, action) => {
+    switch (action.type) {
+        case 'SET_MAP':
+            return {
+                ...state,
+                map: action.payload,
+            }
+        default:
+            return state
+    }
+}

--- a/frontend/src/context/parking_data.js
+++ b/frontend/src/context/parking_data.js
@@ -7,6 +7,7 @@ export const parkingDataInitialState = {
         uid: null,
         capacity_estimate: null,
     },
+    history: [],
     locations: [],
     filtered: [],
 }
@@ -28,6 +29,11 @@ export const parkingDataReducer = (state, action) => {
             return {
                 ...state,
                 filtered: [...action.payload],
+            }
+        case 'SET_HISTORY':
+            return {
+                ...state,
+                history: [...action.payload],
             }
         default:
             return state

--- a/frontend/src/context/parking_data.js
+++ b/frontend/src/context/parking_data.js
@@ -6,6 +6,7 @@ export const parkingDataInitialState = {
     selected: {
         uid: null,
         capacity_estimate: null,
+        statistics: false,
     },
     history: [],
     locations: [],

--- a/frontend/src/services/parking.js
+++ b/frontend/src/services/parking.js
@@ -32,3 +32,22 @@ export const getParkingHistory = async (uid, limit) => {
         console.error(e)
     }
 }
+
+export const getPopularParkingAreas = async (fromDate, toDate, limit, offset) => {
+    try {
+        const { data } = await axios.get(
+            API +
+                '/parking_area_statistics/popular/' +
+                encodeURIComponent(fromDate) +
+                '/' +
+                encodeURIComponent(toDate) +
+                '/' +
+                limit +
+                '/' +
+                offset,
+        )
+        return data
+    } catch (e) {
+        console.error(e)
+    }
+}


### PR DESCRIPTION
lisää uuden reitin, jonka avulla voi hakea kiireisimmät parkkipaikat ajan, ja määrän mukaan

```/parking_area_statistics/popular/:from/:to/:limit/:offset```

from ja to on js Date

swagger puuttuu

---

extra:

parkkipaikoilla ei oo nimiä vaan löytyy vaan lat, ja long. niiden mukaan kuitenkin pystyis hakemaan kadun nimen [https://nominatim.org/release-docs/develop/api/Reverse/](https://nominatim.org/release-docs/develop/api/Reverse/) avulla. 

tuolta pitäis vaan hakee jokasen meiän tietokannasta löytyvän parkkipaikan kadunnimi ja laittaa se omaan pöytään. sama periaate ku [täs](https://github.com/breeku/Web-sovelluskehitys-2-projekti/blob/main/backend/src/database/seeds/01-parking_area.js)
